### PR TITLE
feat(stewardship): admin on/off toggle hides page + side-nav link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.1",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.1",
+      "version": "2.1.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/src/App/AppTemplate/SideMenuItem.tsx
+++ b/src/App/AppTemplate/SideMenuItem.tsx
@@ -3,7 +3,7 @@ import {
   useContext, useEffect,
 } from 'react';
 import { AuthContext, Iauth } from 'src/providers/Auth.provider';
-import type { Ibook } from 'src/providers/utils';
+import { type Ibook, stewardshipEnabled } from 'src/providers/utils';
 import commonUtils from 'src/lib/commonUtils';
 import { ContentContext } from 'src/providers/Content.provider';
 import type { ImenuItem } from './menuConfig';
@@ -101,7 +101,7 @@ export function SideMenuItem(props: IsideMenuItemProps) {
   const {
     menu, index, handleClose,
   } = props;
-  const { news: { newsContent }, getNews } = useContext(ContentContext);
+  const { news: { newsContent }, getNews, content } = useContext(ContentContext);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { (async () => { await getNews(); })(); }, []);
   const { auth } = useContext(AuthContext);
@@ -113,6 +113,9 @@ export function SideMenuItem(props: IsideMenuItemProps) {
   if (m.name === 'Bulletin') {
     m = setBulletin(m, newsContent);
   }
+  // Stewardship is seasonal: hide its nav link unless an admin has toggled the
+  // stewardship content doc's `enabled` flag on (default off → hidden). (CollegeLutheran#707)
+  if (m.name === 'Stewardship' && !stewardshipEnabled(content)) return null;
   if (!utils.showNav(isAllowed, location, m, auth)) return null;
   if (m.link) {
     return (

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -3,6 +3,8 @@ import {
 } from 'react-router-dom';
 import { useContext, useEffect, useState } from 'react';
 import { AuthContext, Iauth } from 'src/providers/Auth.provider';
+import { ContentContext } from 'src/providers/Content.provider';
+import { stewardshipEnabled } from 'src/providers/utils';
 import DefaultMusic from '../containers/Music';
 import { Beliefs } from '../containers/Beliefs';
 import { Giving } from '../containers/Giving';
@@ -37,8 +39,12 @@ export function showAdminDashboard(isAdmin: boolean) {
 
 export function App() {
   const { auth } = useContext(AuthContext);
+  const { content } = useContext(ContentContext);
   const [isAdmin, setIsAdmin] = useState(false);
   useEffect(() => { checkIsAdmin(auth, setIsAdmin); }, [auth]);
+  // Stewardship is seasonal: block the route (direct URL too) unless an admin
+  // has enabled it; default off → redirect home. (CollegeLutheran#707)
+  const stewardshipOn = stewardshipEnabled(content);
   return (
     <div id="App" className="App">
       <AppTemplate>
@@ -55,7 +61,7 @@ export function App() {
           <Route path="/news" element={<News />} />
           <Route path="/calendar" element={<Calendar />} />
           <Route path="/livestream" element={<DefaultLiveStream />} />
-          <Route path="/stewardship" element={<Stewardship />} />
+          <Route path="/stewardship" element={stewardshipOn ? <Stewardship /> : <Navigate to="/" replace />} />
           {/* <Route path="/habitatproject" element={<HabitatProject />} /> */}
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/src/containers/AdminDashboard/AdminDashboardContent.tsx
+++ b/src/containers/AdminDashboard/AdminDashboardContent.tsx
@@ -32,14 +32,15 @@ export function ChangeYouthPageSect() {
   );
 }
 
-// export function ChangeStewardshipPageSect() {
-//   return (
-//     <ChangePageSection
-//       pageType="stewardshipPage"
-//       formTitle="Stewardshippage Section"
-//     />
-//   );
-// }
+export function ChangeStewardshipPageSect() {
+  return (
+    <ChangePageSection
+      pageType="stewardshipPage"
+      formTitle="Stewardshippage Section"
+      withToggle
+    />
+  );
+}
 
 // export function ChangeHabitatPageSect() {
 //   return (
@@ -163,7 +164,7 @@ export function AdminDashboardContent() {
         <>
           <ChangeHomePageSect />
           {/* <ChangeHabitatPageSect /> */}
-          {/* <ChangeStewardshipPageSect /> */}
+          <ChangeStewardshipPageSect />
           <ChangeYouthPageSect />
         </>
       ) : null}

--- a/src/containers/AdminDashboard/ChangePageSection.tsx
+++ b/src/containers/AdminDashboard/ChangePageSection.tsx
@@ -2,7 +2,7 @@ import { SetStateAction, useContext, useState } from 'react';
 import { Editor } from '@tinymce/tinymce-react';
 import { ContentContext } from 'src/providers/Content.provider';
 import { AuthContext } from 'src/providers/Auth.provider';
-import { Button } from '@mui/material';
+import { Button, Switch, FormControlLabel } from '@mui/material';
 import forms from 'src/lib/forms';
 import utils from './utils';
 
@@ -44,12 +44,14 @@ export function UpdateButton(
     comments = '',
     buttonName,
     type,
+    enabled,
   }: {
     title: string,
     getContent: () => Promise<void>,
     comments?: string,
     buttonName: string,
-    type: 'habitatPageContent' | 'homePageContent' | 'stewardshipPageContent' | 'youthPageContent'
+    type: 'habitatPageContent' | 'homePageContent' | 'stewardshipPageContent' | 'youthPageContent',
+    enabled?: boolean,
   },
 ) {
   const { auth } = useContext(AuthContext);
@@ -60,7 +62,9 @@ export function UpdateButton(
         variant="contained"
         type="button"
         id="c-h"
-        onClick={() => utils.putAPI({ title, comments, type }, auth, getContent)}
+        onClick={() => utils.putAPI({
+          title, comments, type, enabled,
+        }, auth, getContent)}
       >
         {buttonName}
       </Button>
@@ -70,13 +74,16 @@ export function UpdateButton(
 
 export interface IchangePageSectionProps {
   pageType: 'habitatPage' | 'stewardshipPage' | 'homePage' | 'youthPage',
-  formTitle: string, withInput?: boolean
+  formTitle: string, withInput?: boolean, withToggle?: boolean
 }
 export function ChangePageSection(props: IchangePageSectionProps) {
-  const { pageType, formTitle, withInput } = props;
+  const {
+    pageType, formTitle, withInput, withToggle,
+  } = props;
   const { content, getContent } = useContext(ContentContext);
   const [comments, setComments] = useState(content[pageType].comments);
   const [title, setTitle] = useState(content[pageType].title);
+  const [enabled, setEnabled] = useState<boolean>(content[pageType].enabled === true);
   const inputParams = {
     type: 'text',
     label: 'Title',
@@ -100,6 +107,12 @@ export function ChangePageSection(props: IchangePageSectionProps) {
           }}
         >
           {withInput ? forms.makeInput(inputParams) : null}
+          {withToggle ? (
+            <FormControlLabel
+              control={<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />}
+              label={enabled ? 'Page visible (on)' : 'Page hidden (off)'}
+            />
+          ) : null}
           <p style={{ fontSize: '12pt', marginTop: '12px', marginBottom: '2px' }}>Content</p>
           <CommentsEditor comments={comments} setComments={setComments} />
           <UpdateButton
@@ -108,6 +121,7 @@ export function ChangePageSection(props: IchangePageSectionProps) {
             comments={comments}
             type={`${pageType}Content`}
             buttonName={`Update ${formTitle}`}
+            enabled={withToggle ? enabled : undefined}
           />
         </form>
       </div>

--- a/src/containers/AdminDashboard/utils.tsx
+++ b/src/containers/AdminDashboard/utils.tsx
@@ -41,7 +41,7 @@ async function handlePutError(e: HttpError,
 }
 
 async function putAPI(
-  data: { title: string; comments: string; type: string },
+  data: { title: string; comments: string; type: string; enabled?: boolean },
   auth: Iauth,
   getContent: () => Promise<void>,
 ): Promise<void> {

--- a/src/providers/utils.tsx
+++ b/src/providers/utils.tsx
@@ -26,6 +26,7 @@ export interface Ibook {
   comments?: string;
   checkedOutBy?: string;
   checkedOutByName?: string;
+  enabled?: boolean;
 }
 
 export interface Icontent {
@@ -48,3 +49,9 @@ export function makeGetter(
 ) {
   return async () => populate(setter);
 }
+
+// Seasonal Stewardship page is visible only when an admin has toggled its
+// content doc's `enabled` flag on; absent/false = hidden. (CollegeLutheran#707)
+export const stewardshipEnabled = (
+  content?: { stewardshipPage?: Ibook },
+): boolean => content?.stewardshipPage?.enabled === true;

--- a/test/containers/providers/utils.spec.tsx
+++ b/test/containers/providers/utils.spec.tsx
@@ -1,0 +1,22 @@
+import { stewardshipEnabled } from 'src/providers/utils';
+import type { Ibook } from 'src/providers/utils';
+
+const doc = (enabled?: boolean): Ibook => ({
+  title: '', _id: '', type: 'stewardshipPageContent', enabled,
+});
+
+describe('stewardshipEnabled', () => {
+  it('is true only when the stewardship doc enabled flag is true', () => {
+    expect(stewardshipEnabled({ stewardshipPage: doc(true) })).toBe(true);
+  });
+  it('is false when enabled is false', () => {
+    expect(stewardshipEnabled({ stewardshipPage: doc(false) })).toBe(false);
+  });
+  it('is false when enabled is absent (default hidden)', () => {
+    expect(stewardshipEnabled({ stewardshipPage: doc() })).toBe(false);
+  });
+  it('is false when content or stewardshipPage is missing', () => {
+    expect(stewardshipEnabled(undefined)).toBe(false);
+    expect(stewardshipEnabled({})).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes **#707**. Frontend for the seasonal Stewardship show/hide. Paired with **web-jam-back#771** (the `enabled` schema field).

## Behavior
Manual admin toggle (persisted as `enabled` on the `stewardshipPageContent` doc). When **off** (default):
- the **Stewardship side-nav link** is hidden, and
- the **`/stewardship` route** redirects to `/` (direct-URL access blocked too).

Hidden for everyone when off; admins re-enable via the dashboard Edit-Content section.

## Changes
- `providers/utils.tsx`: `enabled?` on `Ibook` + shared `stewardshipEnabled(content)` predicate (unit-tested).
- `SideMenuItem`: hide the Stewardship nav item unless enabled.
- `App/index.tsx`: guard `/stewardship` (redirect home when disabled).
- `AdminDashboard`: restored the previously commented-out Stewardship edit section + an on/off **Switch**; `enabled` flows through `putAPI` on save.
- **126 tests pass**, tsc + eslint + stylelint clean. Semver 2.1.3 → 2.1.4 (+ lockfile).

## How to Test Locally
```bash
git checkout feat-stewardship-toggle
npm install
npm test
npm run dev   # http://localhost:7777
```
With web-jam-back#771 running: as admin, Dashboard → Edit Content → Stewardship → flip the switch + Update. Off = nav link gone and `/stewardship` redirects home; on = both return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)