### PR TITLE
fix(stewardship+livestream): editable stewardship body, livestream date label, admin title typo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminDashboard/AdminDashboardContent.tsx
+++ b/src/containers/AdminDashboard/AdminDashboardContent.tsx
@@ -36,7 +36,7 @@ export function ChangeStewardshipPageSect() {
   return (
     <ChangePageSection
       pageType="stewardshipPage"
-      formTitle="Stewardshippage Section"
+      formTitle="Stewardship Page Section"
       withToggle
     />
   );

--- a/src/containers/LiveStream/index.tsx
+++ b/src/containers/LiveStream/index.tsx
@@ -14,14 +14,14 @@ export interface LiveStreamProps {
 }
 export const LiveStream = ({ width }: LiveStreamProps) => {
   commonUtils.setTitleAndScroll('Livestream', window.screen.width);
-  const [videoId, setVideoId] = useState<string | null>(null);
+  const [info, setInfo] = useState<{ videoId: string | null; status?: string; publishedAt?: string }>({ videoId: null });
   useEffect(() => {
     let active = true;
     const load = async () => {
       try {
         const res = await fetch(`${process.env.BackendUrl}/livestream/current`);
-        const data = await res.json() as { videoId: string | null };
-        if (active && data?.videoId) setVideoId(data.videoId);
+        const data = await res.json() as { videoId: string | null; status?: string; publishedAt?: string };
+        if (active && data?.videoId) setInfo(data);
       } catch { /* no video available → fall back to the links below */ }
     };
     void load();
@@ -29,7 +29,17 @@ export const LiveStream = ({ width }: LiveStreamProps) => {
   }, []);
   // Only render the embed when the backend gives us a real video id; otherwise
   // the page shows just the links (no stale YouTube "waiting" placeholder).
-  const src = videoId ? `https://www.youtube.com/embed/${videoId}` : null;
+  const src = info.videoId ? `https://www.youtube.com/embed/${info.videoId}` : null;
+  // Tell visitors which stream they're seeing: the active service, or the date
+  // of the most recent recorded one. publishedAt comes from web-jam-back.
+  const streamLabel = (): string => {
+    if (info.status === 'live') return 'Live now';
+    if (info.publishedAt) {
+      return `Most recent service — ${new Date(info.publishedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`;
+    }
+    if (src) return 'Most recent recorded service';
+    return '';
+  };
   return (
     <div style={{ margin: 'auto', width: '100%', textAlign: 'center' }}>
       {width > 600 ? <h5 style={{ marginTop: '0.5rem' }}>Welcome to Our Livestream Page</h5> : null}
@@ -61,6 +71,9 @@ export const LiveStream = ({ width }: LiveStreamProps) => {
         -
         These links also provide a way to view previous church services that were recorded.
       </p>
+      {src ? (
+        <p style={{ fontWeight: 'bold', margin: '6px 0' }} data-testid="stream-label">{streamLabel()}</p>
+      ) : null}
       {src && width > 931 ? (
         <iframe
           title="Live Stream Wide"

--- a/src/containers/Stewardship/StewardshipContent.tsx
+++ b/src/containers/Stewardship/StewardshipContent.tsx
@@ -1,79 +1,35 @@
 /* eslint-disable max-len */
+import { useContext } from 'react';
+import parser from 'html-react-parser';
 import ELCALogo from 'src/components/elcaLogo';
+import { ContentContext } from 'src/providers/Content.provider';
 
-const StewardshipContent = () => (
-  <div className="page-content">
-    <div className="container-fluid">
-      <p style={{ fontSize: '4pt', margin: '0' }}>&nbsp;</p>
-      <div
-        className="material-content elevation3"
-        style={{
-          maxWidth: '998px', margin: 'auto', minHeight: '74vh',
-        }}
-      >
-        <h3 style={{ paddingTop: '12px', paddingBottom: '0px', marginBottom: '4px' }}>Stewardship</h3>
-        <img
-          style={{ float: 'right' }}
-          alt="fall stewardship"
-          src="https://dl.dropboxusercontent.com/scl/fi/la8fjnoppc97zt1koxsqz/fallStewardship.jpg?rlkey=u60j5qhaq2h21ckytmgb8dqi0&dl=0"
-        />
-        <i style={{ fontSize: '12pt' }}>
-          Click here to
-          {' '}
-          <a
-            style={{ fontSize: '12pt' }}
-            href="https://forms.gle/7UC5r6Y4GknFans39"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <strong>provide your 2026 Statement of Intent</strong>
-          </a>
-          .
-        </i>
-        <p style={{ marginTop: '10px' }}>
-          &quot;So if anyone is in Christ, there is a new creation: everything old has passed away; look, new things have come into being!&quot; (II Corinthians 5:17)
-        </p>
-        <p>
-          As College Lutheran Church, our mission is to celebrate God&apos;s grace and share His love in Christ! We give thanks for the new creation that God the Father works in our hearts through the ministry of His Son and the power of the Holy Spirit. In just this past year, we have continued to gather for faithful worship and we have gone out to serve our neighbors nearby and faraway. Thank you for supporting the ministries of College Lutheran Church!
-        </p>
-        <p>
-          In the year ahead, we hope that you will prayerfully consider how you will continue to support CLC with your gifts of time, talents, and offerings. Some anticipated needs in
-          {' '}
-          <strong>2026</strong>
-          {' '}
-          include:
-        </p>
-        <ul>
-          <li>
-            Updates to the Fellowship Hall to better fit our meals and programs
-            <br />
-            — about $10,000 to improve sound, lighting, and video projection.
-          </li>
-          <li>
-            Meeting increased costs related to insurance, utilities, and cost of living
-            <br />
-            — CLC is a very active congregation all week long! Although this increases expenses, we would not have it any other way!
-          </li>
-        </ul>
-        <p>
-          In total, we are hoping for an increase of $390 in weekly giving in
-          {' '}
-          <strong>2026</strong>
-          {' '}
-          so that we can fully fund our ministries. Every gift matters and helps us to continue celebrating the work God does in our community and through our community. Please consider how your giving can join with the gifts of members and friends of CLC who will support these ministries in
-          {' '}
-          <strong>2026</strong>
-          !
-        </p>
-        <p>
-          With thanks,
-        </p>
-        <p style={{ marginBottom: '0px' }}>
-          Pastor David Drebes & the Stewardship Team
-        </p>
+// The Title and the graphic are fixed; everything below the image is the
+// admin-editable body, managed in the dashboard's Stewardship content editor
+// and stored as stewardshipPage.comments. (CollegeLutheran#707)
+const StewardshipContent = () => {
+  const { content: { stewardshipPage } } = useContext(ContentContext);
+  return (
+    <div className="page-content">
+      <div className="container-fluid">
+        <p style={{ fontSize: '4pt', margin: '0' }}>&nbsp;</p>
+        <div
+          className="material-content elevation3"
+          style={{
+            maxWidth: '998px', margin: 'auto', minHeight: '74vh',
+          }}
+        >
+          <h3 style={{ paddingTop: '12px', paddingBottom: '0px', marginBottom: '4px' }}>Stewardship</h3>
+          <img
+            style={{ float: 'right' }}
+            alt="fall stewardship"
+            src="https://dl.dropboxusercontent.com/scl/fi/la8fjnoppc97zt1koxsqz/fallStewardship.jpg?rlkey=u60j5qhaq2h21ckytmgb8dqi0&dl=0"
+          />
+          {parser(stewardshipPage && stewardshipPage.comments ? stewardshipPage.comments : '')}
+        </div>
+        <ELCALogo />
       </div>
-      <ELCALogo />
     </div>
-  </div>
-);
+  );
+};
 export default StewardshipContent;

--- a/test/containers/Stewardship/StewardshipContent.spec.tsx
+++ b/test/containers/Stewardship/StewardshipContent.spec.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen } from '@testing-library/react';
+import StewardshipContent from 'src/containers/Stewardship/StewardshipContent';
+import { ContentContext } from 'src/providers/Content.provider';
+
+const renderWith = (comments?: string) => {
+  const value: any = {
+    content: { stewardshipPage: { title: '', _id: '', type: 'stewardshipPageContent', comments } },
+  };
+  return render(
+    <ContentContext.Provider value={value}><StewardshipContent /></ContentContext.Provider>,
+  );
+};
+
+describe('StewardshipContent', () => {
+  it('keeps the fixed title and graphic', () => {
+    renderWith();
+    expect(screen.getByText('Stewardship')).toBeTruthy();
+    expect(screen.getByAltText('fall stewardship')).toBeTruthy();
+  });
+  it('renders the admin-editable body from stewardshipPage.comments', () => {
+    renderWith('<p>Give generously this fall</p>');
+    expect(screen.getByText('Give generously this fall')).toBeTruthy();
+  });
+});

--- a/test/containers/livestream.spec.tsx
+++ b/test/containers/livestream.spec.tsx
@@ -33,4 +33,16 @@ describe('LiveStream', () => {
     await screen.findByText('Facebook Videos');
     await waitFor(() => expect(screen.queryByTitle('Live Stream Small')).toBeNull());
   });
+
+  it('labels a live stream as "Live now"', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => okJson({ videoId: 'VID123', status: 'live' })));
+    render(<LiveStream width={950} />);
+    expect((await screen.findByTestId('stream-label')).textContent).toBe('Live now');
+  });
+
+  it('labels a completed stream with its date', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => okJson({ videoId: 'VID123', status: 'completed', publishedAt: '2026-05-25T15:00:00Z' })));
+    render(<LiveStream width={950} />);
+    expect((await screen.findByTestId('stream-label')).textContent).toContain('May 25, 2026');
+  });
 });


### PR DESCRIPTION
Three fixes from review (all CollegeLutheran frontend).

## 1. Stewardship body now admin-editable
`StewardshipContent` was fully hardcoded, so the dashboard editor's content was saved but never shown. Now the **Title and the fall graphic stay fixed**, and everything below is rendered from `stewardshipPage.comments` (`html-react-parser`) — so admins control the body from Dashboard → Edit Content → Stewardship.

> Note: on deploy the page body becomes whatever's in the content doc, so populate the Stewardship editor with the desired text (the old hardcoded copy) once.

## 2. Livestream date label
The page didn't say which stream was showing. Now it displays **"Live now"** or **"Most recent service — \<date\>"**, from `status`/`publishedAt` on `/livestream/current`. Degrades to a status-only label until the backend returns the date — see paired **web-jam-back** PR (adds `publishedAt`).

## 3. Admin title typo
`"Stewardshippage Section"` → `"Stewardship Page Section"`.

## Tests
New: livestream label (live + dated), StewardshipContent (fixed title/graphic + editable body). **130 tests pass**, tsc + eslint + stylelint clean. Semver 2.1.4 → 2.1.5 (+ lockfile).

## How to Test Locally
```bash
git checkout fix-livestream-date-stewardship-title
npm install && npm test && npm run dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)