### PR TITLE
fix(cl): Maria review items 1-3 — broken link + mobile overflow (calendar/facebook/giving)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -41,6 +41,14 @@ export function App() {
   const { auth } = useContext(AuthContext);
   const { content } = useContext(ContentContext);
   const [isAdmin, setIsAdmin] = useState(false);
+  // Track the real viewport width (and keep it current on resize/rotate) so the
+  // homepage can pick its narrow vs wide feed instead of always rendering wide.
+  const [width, setWidth] = useState(window.innerWidth);
+  useEffect(() => {
+    const onResize = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
   useEffect(() => { checkIsAdmin(auth, setIsAdmin); }, [auth]);
   // Stewardship is seasonal: block the route (direct URL too) unless an admin
   // has enabled it; default off → redirect home. (CollegeLutheran#707)
@@ -49,7 +57,7 @@ export function App() {
     <div id="App" className="App">
       <AppTemplate>
         <Routes>
-          <Route path="/" element={<DefaultHome width={900} />} />
+          <Route path="/" element={<DefaultHome width={width} />} />
           <Route path="/music" element={<DefaultMusic />} />
           <Route path="/belief" element={<Beliefs />} />
           <Route path="/family" element={<Family />} />

--- a/src/containers/Calendar/CalendarContent.tsx
+++ b/src/containers/Calendar/CalendarContent.tsx
@@ -9,7 +9,7 @@ const CalendarContent = () => (
           height=900&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=ra8um2u26p59a2t92lfooq4els%40group.calendar.google.com&amp;
           color=%23060D5E&amp;ctz=America%2FNew_York"
           style={{ borderWidth: '0' }}
-          width="900"
+          width="100%"
           height="900"
           frameBorder="0"
           scrolling="no"

--- a/src/containers/Family/FamilyContent.tsx
+++ b/src/containers/Family/FamilyContent.tsx
@@ -6,7 +6,7 @@ import PicSlider from '../../components/PicSlider';
 import ELCALogo from '../../components/elcaLogo';
 
 // eslint-disable-next-line max-len
-const additionalContent = '<hr><h5>Resources for Families</h5><p><strong><em>Roots and Wings</em></strong>, a monthly publication of the Virginia Synod that provides suggestions of daily family time activities:<a target="_blank" href="https://www.vasynod.org/ministries/roots-and-wings/">https://www.vasynod.org/ministries/roots-and-wings/</a></p><p><strong>Ideas to bring worship to the home:</strong>&nbsp;<a target="_blank" href="https://www.vasynod.org/wp-content/uploads/2012/11/Worship-in-the-Home.pdf">https://www.vasynod.org/wp-content/uploads/2012/11/Worship-in-the-Home.pdf</a></p><p><strong>Hand Prayer:</strong>&nbsp;<a target="_blank" href="http://www.vibrantfaithathome.org/item/hand-prayers">http://www.vibrantfaithathome.org/item/hand-prayers</a></p>';
+const additionalContent = '<hr><h5>Resources for Families</h5><p><strong><em>Roots and Wings</em></strong>, a monthly publication of the Virginia Synod that provides suggestions of daily family time activities:<a target="_blank" href="https://www.vasynod.org/ministries/roots-and-wings/">https://www.vasynod.org/ministries/roots-and-wings/</a></p><p><strong>Ideas to bring worship to the home:</strong>&nbsp;<a target="_blank" href="https://www.vasynod.org/wp-content/uploads/2012/11/Worship-in-the-Home.pdf">https://www.vasynod.org/wp-content/uploads/2012/11/Worship-in-the-Home.pdf</a></p>';
 const FamilySection = () => (
   <section style={{ textAlign: 'left' }}>
     <p>

--- a/src/containers/Giving/GivingContent.tsx
+++ b/src/containers/Giving/GivingContent.tsx
@@ -62,22 +62,18 @@ export function GivingContent() {
         <GivingInfo />
       </Box>
 
-      {/* 2. Donation Iframe Wrapper - Handles the horizontal scroll */}
-      <Box
-        sx={{
-          width: '100%',
-          maxWidth: 1200, // Matches your desired content width
-          height: '800px',
-          overflowX: 'auto', // Forces horizontal scrollbar
-          border: '1px solid #eee', // Optional: helps see the scroll area
-          '&::-webkit-scrollbar': { height: '10px' },
-          '&::-webkit-scrollbar-thumb': { backgroundColor: '#ccc', borderRadius: '4px' },
-        }}
+      {/* 2. Donation iframe — responsive: fills the available width so the
+          Breeze give form fits the viewport (taller on phones where the form
+          stacks vertically), instead of being forced to 1000px and pushed
+          off-screen on mobile. */}
+      <Box sx={{
+        width: '100%',
+        maxWidth: 1200,
+        height: { xs: '1100px', sm: '800px' },
+        px: { xs: 1, sm: 0 },
+      }}
       >
-        {/* This inner Box MUST be wider than the wrapper to trigger the scrollbar */}
-        <Box sx={{ minWidth: '1000px', height: '100%' }}>
-          <GivingDonation />
-        </Box>
+        <GivingDonation />
       </Box>
 
       {/* 3. Footer/Logo Section */}

--- a/test/containers/Calendar/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Calendar/__snapshots__/index.spec.tsx.snap
@@ -26,7 +26,7 @@ exports[`Calendar > renders correctly 1`] = `
           color=%23060D5E&ctz=America%2FNew_York"
           style="border-width: 0px;"
           title="Church Calendar"
-          width="900"
+          width="100%"
         />
       </div>
     </div>

--- a/test/containers/Family/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Family/__snapshots__/index.spec.tsx.snap
@@ -94,18 +94,6 @@ exports[`Family > renders correctly without images 1`] = `
               https://www.vasynod.org/wp-content/uploads/2012/11/Worship-in-the-Home.pdf
             </a>
           </p>
-          <p>
-            <strong>
-              Hand Prayer:
-            </strong>
-             
-            <a
-              href="http://www.vibrantfaithathome.org/item/hand-prayers"
-              target="_blank"
-            >
-              http://www.vibrantfaithathome.org/item/hand-prayers
-            </a>
-          </p>
         </section>
       </div>
       <div

--- a/test/containers/__snapshots__/giving.spec.tsx.snap
+++ b/test/containers/__snapshots__/giving.spec.tsx.snap
@@ -36,24 +36,20 @@ exports[`Giving > Renders the Giving component 1`] = `
       </div>
     </div>
     <div
-      class="MuiBox-root css-1emsdqd"
+      class="MuiBox-root css-pceey"
     >
-      <div
-        class="MuiBox-root css-3ioch2"
+      <iframe
+        class="giving-iframe"
+        height="100%"
+        src="https://collegelutheranchurch.breezechms.com/give/online"
+        style="overflow-x: scroll;"
+        title="Just Giving"
+        width="100%"
       >
-        <iframe
-          class="giving-iframe"
-          height="100%"
-          src="https://collegelutheranchurch.breezechms.com/give/online"
-          style="overflow-x: scroll;"
-          title="Just Giving"
-          width="100%"
-        >
-          <p>
-            Your browser does not support iframe.
-          </p>
-        </iframe>
-      </div>
+        <p>
+          Your browser does not support iframe.
+        </p>
+      </iframe>
     </div>
     <div
       class="MuiBox-root css-h5fkc8"


### PR DESCRIPTION
Maria's CollegeLutheran review (6/4/26), items 1–3. Item 4 (slideshow photos) is content-driven and tracked separately.

## Changes
1. **Family page — broken "Hand Prayer" link removed.** `vibrantfaithathome.org/item/hand-prayers` now resolves to a parked "Affordable, Reliable Web Hosting" page. The two other Resources-for-Families links stay. (Josh confirmed: delete, don't replace.)
2. **Mobile overflow (calendar + Facebook).** Google Calendar iframe `width="900"`→`"100%"` so it fits the viewport; the homepage now passes the **real** viewport width to `DefaultHome` (it was hardcoded to `900`, which always rendered the wide Facebook feed) with a resize listener, so phones get the narrow feed instead of one running off-screen.
3. **Giving page mobile.** Dropped the forced `minWidth:1000px` inner scroll box; the Breeze donation iframe is now responsive (`maxWidth:1200`, taller `1100px` on `xs`) so the give form fits the phone screen.

Version 2.1.7 → 2.1.8, lockfile synced, 3 snapshots updated.

## How to Test Locally
```bash
cd ~/WebJamApps/CollegeLutheran
git checkout fix-cl-maria-review-1-2-3 && npm install
npm test            # lint + 130 unit tests, all green
npm run dev         # then in the browser, with device toolbar / a real phone:
```
- **/family** — the "Resources for Families" list no longer shows a "Hand Prayer" line; the two remaining links work.
- **/** (home) — at narrow widths the Facebook feed uses the narrow layout and doesn't run off-screen.
- **/calendar** — the calendar fills the width and doesn't overflow horizontally on a phone.
- **/giving** — the "Give to College Lutheran Church" Breeze box is fully on-screen on a phone (no horizontal scroll needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)