### PR TITLE
fix(cl): show only the Facebook post feed (crop the duplicate page header)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.10",
+      "version": "2.1.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/Homepage/NarrowFacebookFeed.tsx
+++ b/src/containers/Homepage/NarrowFacebookFeed.tsx
@@ -16,13 +16,19 @@ const FacebookIframe = () => (
         <a style={{ fontSize: '10pt' }} href="https://www.facebook.com/CollegeLutheranChurch/">Facebook</a>
       </i>
     </p>
-    <div style={{ maxWidth: '300px', margin: 'auto', marginBottom: 0 }}>
+    {/* Crop the page-plugin's own header (~56px) so only the post feed shows
+        (it otherwise duplicates the first post's "College Lutheran Church"
+        header). */}
+    <div style={{
+      maxWidth: '300px', margin: 'auto', marginBottom: 0, height: '500px', overflow: 'hidden',
+    }}
+    >
       <iframe
         title="clc-facebook" /* eslint-disable-next-line max-len */
-        src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FCollegeLutheranChurch&tabs=timeline&width=300&height=500&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=false"
+        src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FCollegeLutheranChurch&tabs=timeline&width=300&height=568&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=false"
         width="300"
-        height="500"
-        style={{ border: 'none', overflow: 'hidden' }}
+        height="568"
+        style={{ border: 'none', overflow: 'hidden', marginTop: '-68px' }}
         loading="lazy"
         scrolling="no"
         frameBorder="0"

--- a/src/containers/Homepage/WideFacebookFeed.tsx
+++ b/src/containers/Homepage/WideFacebookFeed.tsx
@@ -43,18 +43,25 @@ const WideFacebookFeed = ({ width = 1004 }: IWideFBFeed) => {
             <a style={{ fontSize: '10pt' }} href="https://www.facebook.com/CollegeLutheranChurch/">Facebook</a>
           </i>
         </p>
-        <iframe
-          className="widescreenHomepage"
-          // eslint-disable-next-line max-len
-          src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FCollegeLutheranChurch&tabs=timeline&width=500&height=485&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=false"
-          width="500"
-          height="485"
-          loading="lazy"
-          style={{ border: 'none', overflow: 'hidden', marginLeft: '-14px' }}
-          scrolling="no"
-          allow="encrypted-media"
-          title="facebook ticker"
-        />
+        {/* Crop the page-plugin's own header (~56px) so only the post feed
+            shows. The plugin always renders a page header above the timeline,
+            which duplicates the first post's author header ("two headers"). */}
+        <div style={{ height: '485px', overflow: 'hidden' }}>
+          <iframe
+            className="widescreenHomepage"
+            // eslint-disable-next-line max-len
+            src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FCollegeLutheranChurch&tabs=timeline&width=500&height=553&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=false"
+            width="500"
+            height="553"
+            loading="lazy"
+            style={{
+              border: 'none', overflow: 'hidden', marginLeft: '-14px', marginTop: '-68px',
+            }}
+            scrolling="no"
+            allow="encrypted-media"
+            title="facebook ticker"
+          />
+        </div>
       </div>
     </div>
   );

--- a/test/containers/Homepage/__snapshots__/WideFacebookFeed.spec.tsx.snap
+++ b/test/containers/Homepage/__snapshots__/WideFacebookFeed.spec.tsx.snap
@@ -52,17 +52,21 @@ exports[`WideFacebookFeed > renders WideFacebookFeed 1`] = `
           </a>
         </i>
       </p>
-      <iframe
-        allow="encrypted-media"
-        class="widescreenHomepage"
-        height="485"
-        loading="lazy"
-        scrolling="no"
-        src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FCollegeLutheranChurch&tabs=timeline&width=500&height=485&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=false"
-        style="border: medium; overflow: hidden; margin-left: -14px;"
-        title="facebook ticker"
-        width="500"
-      />
+      <div
+        style="height: 485px; overflow: hidden;"
+      >
+        <iframe
+          allow="encrypted-media"
+          class="widescreenHomepage"
+          height="553"
+          loading="lazy"
+          scrolling="no"
+          src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FCollegeLutheranChurch&tabs=timeline&width=500&height=553&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=false"
+          style="border: medium; overflow: hidden; margin-left: -14px; margin-top: -68px;"
+          title="facebook ticker"
+          width="500"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/test/e2e/homepage.spec.ts
+++ b/test/e2e/homepage.spec.ts
@@ -20,8 +20,8 @@ test('renders the homepage with its key sections', async ({ page }) => {
 });
 
 test('shows exactly one Facebook feed (no duplicated embed)', async ({ page }) => {
-  // Only one feed renders per viewport (wide OR narrow). Two would mean the
-  // duplicate-feed regression is back.
+  // Only one embed renders per viewport (wide OR narrow). Two would mean a
+  // duplicated Facebook section is back.
   const feeds = page.locator('iframe[src*="plugins/page.php"]');
   await expect(feeds).toHaveCount(1);
 });


### PR DESCRIPTION
The homepage "Like Us On Facebook" section showed **two stacked "College Lutheran Church" headers**: Facebook's page plugin always renders a page-header card (avatar, name, follower count, Follow) above the timeline, and the first post repeats the same page name/avatar.

## Cause
No Facebook page-plugin parameter hides the header while keeping the post feed (`tabs=timeline` always draws the header). web-jam.com uses the same widget and only looks clean because that page rarely posts, so its timeline shows essentially one header.

## Fix
Crop the plugin's own header (~68px) with an `overflow:hidden` wrapper + negative `margin-top` on the iframe (iframe height bumped to compensate), on both the **wide** and **narrow** homepage feeds. Result: the "Like Us On Facebook" link, then straight into the post feed — no duplicate page-header card. Verified visually on the running dev server.

Version 2.1.10 → 2.1.11; snapshot updated; homepage Playwright e2e still green (6/6).

## How to Test Locally
```bash
cd ~/WebJamApps/CollegeLutheran
git checkout fix-cl-facebook-single-card && npm install
npm test                 # lint + 130 unit tests
npm run test:e2e         # 6 e2e (desktop + mobile)
npm run dev              # open / on desktop and a phone width
```
- The Facebook section shows the **post feed only** — no "College Lutheran Church · NNN followers" card stacked above the first post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)