### PR TITLE
test(cl): add mobile-only homepage layout e2e checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/test/e2e/homepage.spec.ts
+++ b/test/e2e/homepage.spec.ts
@@ -34,3 +34,36 @@ test('has no horizontal overflow', async ({ page }) => {
   });
   expect(overflow, `unexpected horizontal overflow of ${overflow}px`).toBeLessThanOrEqual(2);
 });
+
+// Mobile-only assertions. The Homepage swaps layouts at 900px
+// (src/containers/Homepage/index.tsx): the narrow phone layout has its own
+// calendar + Facebook column (titles clc-calendar / clc-facebook) while the
+// wide desktop layout uses a two-column row (titles google-calendar /
+// "facebook ticker", header id #wideFacebook). These tests guard that a phone
+// actually gets the narrow layout and never the desktop one.
+test.describe('mobile layout', () => {
+  test.beforeEach(({ page: _page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile', 'mobile viewport only');
+  });
+
+  test('renders the narrow phone layout, not the wide desktop one', async ({ page }) => {
+    await expect(page.locator('iframe[title="clc-facebook"]')).toBeAttached();
+    await expect(page.locator('iframe[title="clc-calendar"]')).toBeAttached();
+    // The desktop two-column layout must not leak onto a phone.
+    await expect(page.locator('iframe[title="facebook ticker"]')).toHaveCount(0);
+    await expect(page.locator('iframe[title="google-calendar"]')).toHaveCount(0);
+    await expect(page.locator('#wideFacebook')).toHaveCount(0);
+  });
+
+  test('the Facebook and calendar embeds fit within the viewport width', async ({ page }) => {
+    // Each embed (and its cropping wrapper) must stay inside the screen so the
+    // phone layout never forces a horizontal scroll.
+    const viewport = page.viewportSize();
+    const width = viewport?.width ?? 0;
+    for (const title of ['clc-facebook', 'clc-calendar']) {
+      const box = await page.locator(`iframe[title="${title}"]`).boundingBox();
+      const right = box ? box.x + box.width : Number.NaN;
+      expect(right, `${title} iframe overflows the ${width}px viewport`).toBeLessThanOrEqual(width + 2);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds **mobile-only** Playwright e2e checks for the CollegeLutheran homepage, guarding the 900px responsive layout swap (`src/containers/Homepage/index.tsx`).

- Asserts a phone gets the **narrow** calendar + Facebook column (`clc-calendar` / `clc-facebook`) and **never** the wide desktop layout (`google-calendar` / `facebook ticker` / `#wideFacebook`).
- Asserts those embeds fit within the viewport width (no horizontal scroll on a phone).

The new tests run on the `mobile` project and skip on `desktop`. Existing desktop/mobile smoke tests are unchanged.

## Why

CL is responsive and swaps layouts at 900px. Mobile-only regressions (the kind Maria reports) are invisible to desktop-only tests. This locks in that the correct layout renders per device.

## How to Test Locally

```bash
cd /home/joshua/WebJamApps/CollegeLutheran
npx playwright test            # both projects: 8 passed, 2 skipped
npx playwright test --project=mobile   # runs the new mobile checks
npx eslint test/e2e/homepage.spec.ts   # clean
```
Tests run against production (`https://www.collegelutheran.org`) by default; override with `BASE_URL` for a local `npm run preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)