### PR TITLE
fix(cl): giving page iframe responsive on mobile + run e2e in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/node:24.15-browsers
+      - image: cimg/node:24.16-browsers
     working_directory: ~/repo
     steps:
       - checkout
@@ -17,6 +17,23 @@ jobs:
           command: npm test
       - store_artifacts:
           path: coverage
+      - run:
+          name: e2e tests (Playwright, desktop + mobile)
+          command: |
+            npx playwright install chromium
+            # Rebuild for production: the postinstall build during `npm install`
+            # runs without NODE_ENV=production and emits React's dev jsxDEV
+            # runtime, which crashes the served bundle. Heroku sets NODE_ENV, so
+            # prod is fine; CI must set it explicitly here. Done after the e2e
+            # browser install so the devDep Playwright is still present.
+            NODE_ENV=production npm run build
+            PORT=7777 node server.mjs &
+            SERVER_PID=$!
+            sleep 5
+            BASE_URL=http://localhost:7777 npm run test:e2e
+            STATUS=$?
+            kill $SERVER_PID || true
+            exit $STATUS
       - run:
           name: Smoketest - clean install without devDependencies
           command: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.11",
+  "version": "2.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.11",
+      "version": "2.1.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/src/styles/_mobile.scss
+++ b/src/styles/_mobile.scss
@@ -386,7 +386,7 @@
   }
 
   .giving-iframe {
-    width: 320px;
+    width: 100%;
     height: 750px;
     border: 1px solid #d3d3d3;
   }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -367,7 +367,8 @@ div.fof {
 /* App/Giving */
 
 .giving-iframe {
-  width: 800px;
+  width: 100%;
+  max-width: 800px;
   height: 750px;
   border: 1px solid #d3d3d3;
 }

--- a/test/e2e/giving.spec.ts
+++ b/test/e2e/giving.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+// Regression tests for the Giving page. Runs on both desktop and mobile
+// (see playwright.config.ts projects). Guards the bug Maria reported on her
+// phone: the Breeze give form iframe was pinned to a fixed 800px width in CSS
+// (.giving-iframe in styles.scss), so on a ~393px phone it rendered 800px wide
+// and got clipped to a centered slice — the form ran off both edges and was
+// unusable. The fix makes the iframe fluid (width:100%, max-width:800px), so it
+// fills the phone viewport and caps at 800px on desktop. The Breeze form is a
+// cross-origin iframe, so we assert on its box/fit, not its contents.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/giving', { waitUntil: 'domcontentloaded' });
+});
+
+test('renders the Giving page with its heading and the Breeze form', async ({ page }) => {
+  await expect(page.getByRole('heading', { name: 'Giving' })).toBeVisible();
+  // The Breeze give form embed is always present.
+  await expect(page.locator('iframe.giving-iframe')).toBeAttached();
+  await expect(page.locator('iframe[src*="breezechms.com"]')).toBeAttached();
+});
+
+test('has no horizontal overflow', async ({ page }) => {
+  // The clipped 800px iframe used to push content off-screen on a phone.
+  const overflow = await page.evaluate(() => {
+    const el = document.scrollingElement || document.documentElement;
+    return el.scrollWidth - el.clientWidth;
+  });
+  expect(overflow, `unexpected horizontal overflow of ${overflow}px`).toBeLessThanOrEqual(2);
+});
+
+test('the give form iframe fits within the viewport width', async ({ page }) => {
+  // Core regression guard: the iframe must never be wider than the screen, and
+  // its right edge must stay inside the viewport (it used to start at a negative
+  // x and overflow on the right, clipping the form on both sides).
+  const viewport = page.viewportSize();
+  const width = viewport?.width ?? 0;
+  const box = await page.locator('iframe.giving-iframe').boundingBox();
+  expect(box, 'giving iframe has no layout box').not.toBeNull();
+  const left = box?.x ?? Number.NaN;
+  const right = box ? box.x + box.width : Number.NaN;
+  expect(left, 'giving iframe starts off the left edge').toBeGreaterThanOrEqual(-2);
+  expect(right, `giving iframe (width ${Math.round(box?.width ?? 0)}) overflows the ${width}px viewport`)
+    .toBeLessThanOrEqual(width + 2);
+});


### PR DESCRIPTION
## Problem
The Giving page Breeze give-form was **clipped and unusable on mobile** (Maria reported it on her phone). The `.giving-iframe` rule in `styles.scss` hardcoded `width: 800px`, which overrode the iframe's `width="100%"` attribute. On a ~393px phone the iframe stayed 800px and rendered as a centered slice starting at x=-112, so the form ran off both edges. The recent "responsive" JSX change in #722's follow-up couldn't help because the CSS pinned both width and height.

## Fix
- `src/styles/styles.scss` — `.giving-iframe` `width: 800px` → `width: 100%; max-width: 800px` (fluid, caps at 800 on desktop)
- `src/styles/_mobile.scss` — conflicting mobile override `320px` → `100%`
- Desktop is unchanged; mobile now fills the viewport and the Breeze form renders its own mobile layout.

## Tests
- `test/e2e/giving.spec.ts` — new Playwright regression tests on **desktop + mobile** asserting the iframe fits inside the viewport. The mobile test **fails against the old build** (`iframe width 800 overflows the 393px viewport`) and passes on the fix.
- **CircleCI now runs the e2e suite** (`.circleci/config.yml`). Previously `npm test` only ran lint + vitest; Playwright never ran in CI.
  - Image bumped `cimg/node:24.15-browsers` → `cimg/node:24.16-browsers` (matches the pinned `24.16.0`).
  - The e2e step **rebuilds with `NODE_ENV=production`** before serving. Without it, `vite build` emits React's dev `jsxDEV` runtime and the served bundle crashes client-side — while `curl /` still returns 200, so the old smoketest never caught it. Heroku sets `NODE_ENV`, so prod was unaffected.

## How to Test Locally
```bash
git checkout fix-cl-giving-mobile
npm install
npm run dev            # serves http://localhost:7777
# open http://localhost:7777/giving
# DevTools (F12) → device toolbar (Ctrl+Shift+M) → Pixel 5: the Breeze form fits and is usable

# run the e2e tests the way CI does:
npx playwright install chromium
NODE_ENV=production npm run build
PORT=7777 node server.mjs &
BASE_URL=http://localhost:7777 npm run test:e2e
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)