### PR TITLE
fix(news): Firefox email-signup fallback + real-DB news-table e2e in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,13 @@ jobs:
             for _ in $(seq 1 30); do curl -sf "http://localhost:7000/book?type=Forum" >/dev/null && break; sleep 2; done
             # Seed several Forum rows so the table renders (and scrolls).
             node test/e2e/seed-news.mjs seed
-            # Rebuild for production: a plain build emits React's dev jsxDEV
-            # runtime and crashes the served bundle (Heroku sets NODE_ENV, CI must
-            # too). Point the frontend at the local backend.
-            NODE_ENV=production BackendUrl=http://localhost:7000 npm run build
+            # Point the frontend at the local backend. Vite reads BackendUrl from
+            # a .env file (loadEnv), and .env is gitignored so CI has none — write
+            # it here, else the build bakes an empty BackendUrl and the browser
+            # fetches a relative /book (index.html, not JSON). NODE_ENV=production
+            # so React uses the prod JSX runtime (a plain build crashes the bundle).
+            printf 'BackendUrl=http://localhost:7000\nPORT=7777\n' > .env
+            NODE_ENV=production npm run build
             PORT=7777 node server.mjs > /tmp/front.log 2>&1 &
             sleep 5
             set +e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,16 @@ jobs:
             # JaMmusic, which we don't need); we then build it with tsc.
             git clone --depth 1 --branch main https://github.com/WebJamApps/web-jam-back.git /tmp/wjb
             ( cd /tmp/wjb && npm ci --ignore-scripts && npx tsc )
-            MONGO_DB_URI="$MONGO_DB_URI" AllowUrl='{"urls":["http://localhost:7777"]}' \
+            # web-jam-back's mongoConnect reads TEST_DB when NODE_ENV=test, else
+            # MONGO_DB_URI — set BOTH to the test DB so it connects either way.
+            MONGO_DB_URI="$MONGO_DB_URI" TEST_DB="$MONGO_DB_URI" \
+              AllowUrl='{"urls":["http://localhost:7777"]}' \
               PORT=7000 node /tmp/wjb/build/src/index.js > /tmp/wjb.log 2>&1 &
             for _ in $(seq 1 30); do curl -sf "http://localhost:7000/book?type=Forum" >/dev/null && break; sleep 2; done
             # Seed several Forum rows so the table renders (and scrolls).
             node test/e2e/seed-news.mjs seed
+            echo "DIAG backend Forum rows:"; curl -s "http://localhost:7000/book?type=Forum" | head -c 300; echo
+            echo "DIAG web-jam-back startup log:"; cat /tmp/wjb.log
             # Point the frontend at the local backend. Vite reads BackendUrl from
             # a .env file (loadEnv), and .env is gitignored so CI has none — write
             # it here, else the build bakes an empty BackendUrl and the browser

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,11 @@ jobs:
             cat /tmp/wjb.log || true
             # Seed several Forum rows so the table renders (and scrolls).
             node test/e2e/seed-news.mjs seed
-            # Point the frontend at the local backend. Vite reads BackendUrl from
-            # a .env file (loadEnv), and .env is gitignored so CI has none — write
-            # it here, else the build bakes an empty BackendUrl and the browser
-            # fetches a relative /book (index.html, not JSON). NODE_ENV=production
-            # so React uses the prod JSX runtime (a plain build crashes the bundle).
-            printf 'BackendUrl=http://localhost:7000\nPORT=7777\n' > .env
-            NODE_ENV=production npm run build
+            # Point the frontend at the local backend via a real env var — Vite's
+            # loadEnv picks up process.env, whereas writing a .env file did NOT bake
+            # into the CI bundle. NODE_ENV=production so React uses the prod JSX
+            # runtime (a plain build crashes the served bundle).
+            BackendUrl=http://localhost:7000 NODE_ENV=production npm run build
             PORT=7777 node server.mjs > /tmp/front.log 2>&1 &
             sleep 5
             echo "DIAG post-seed backend rows:"; curl -s "http://localhost:7000/book?type=Forum" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{console.log(JSON.parse(d).length)}catch(e){console.log('parse-fail:'+d.slice(0,80))}})" || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,21 +18,33 @@ jobs:
       - store_artifacts:
           path: coverage
       - run:
-          name: e2e tests (Playwright, desktop + mobile)
+          name: e2e tests (Playwright + real web-jam-back on the test DB)
           command: |
             npx playwright install chromium
-            # Rebuild for production: the postinstall build during `npm install`
-            # runs without NODE_ENV=production and emits React's dev jsxDEV
-            # runtime, which crashes the served bundle. Heroku sets NODE_ENV, so
-            # prod is fine; CI must set it explicitly here. Done after the e2e
-            # browser install so the devDep Playwright is still present.
-            NODE_ENV=production npm run build
-            PORT=7777 node server.mjs &
-            SERVER_PID=$!
+            # Start a real web-jam-back (public repo) against the TEST MongoDB so
+            # the News table is populated by the real API — no stubs. MONGO_DB_URI
+            # is the test DB (never prod), set as a CircleCI project env var.
+            # --ignore-scripts skips web-jam-back's postinstall (it pulls in
+            # JaMmusic, which we don't need); we then build it with tsc.
+            git clone --depth 1 --branch main https://github.com/WebJamApps/web-jam-back.git /tmp/wjb
+            ( cd /tmp/wjb && npm ci --ignore-scripts && npx tsc )
+            MONGO_DB_URI="$MONGO_DB_URI" AllowUrl='{"urls":["http://localhost:7777"]}' \
+              PORT=7000 node /tmp/wjb/build/src/index.js > /tmp/wjb.log 2>&1 &
+            for _ in $(seq 1 30); do curl -sf "http://localhost:7000/book?type=Forum" >/dev/null && break; sleep 2; done
+            # Seed several Forum rows so the table renders (and scrolls).
+            node test/e2e/seed-news.mjs seed
+            # Rebuild for production: a plain build emits React's dev jsxDEV
+            # runtime and crashes the served bundle (Heroku sets NODE_ENV, CI must
+            # too). Point the frontend at the local backend.
+            NODE_ENV=production BackendUrl=http://localhost:7000 npm run build
+            PORT=7777 node server.mjs > /tmp/front.log 2>&1 &
             sleep 5
-            BASE_URL=http://localhost:7777 npm run test:e2e
+            set +e
+            E2E_SEEDED=1 BASE_URL=http://localhost:7777 npm run test:e2e
             STATUS=$?
-            kill $SERVER_PID || true
+            set -e
+            # Always remove the rows we seeded, pass or fail.
+            node test/e2e/seed-news.mjs cleanup
             exit $STATUS
       - run:
           name: Smoketest - clean install without devDependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,16 +28,18 @@ jobs:
             # JaMmusic, which we don't need); we then build it with tsc.
             git clone --depth 1 --branch main https://github.com/WebJamApps/web-jam-back.git /tmp/wjb
             ( cd /tmp/wjb && npm ci --ignore-scripts && npx tsc )
-            # web-jam-back's mongoConnect reads TEST_DB when NODE_ENV=test, else
-            # MONGO_DB_URI — set BOTH to the test DB so it connects either way.
-            MONGO_DB_URI="$MONGO_DB_URI" TEST_DB="$MONGO_DB_URI" \
+            # web-jam-back only calls app.listen when NODE_ENV !== 'test', reads
+            # MONGO_DB_URI when NODE_ENV !== 'test', and runs a dev-only song
+            # reseed when NODE_ENV !== 'production'. CI's NODE_ENV is 'test', which
+            # would skip listen entirely — so run it explicitly as production: it
+            # listens, reads MONGO_DB_URI (the test DB), and skips the reseed.
+            NODE_ENV=production MONGO_DB_URI="$MONGO_DB_URI" \
               AllowUrl='{"urls":["http://localhost:7777"]}' \
               PORT=7000 node /tmp/wjb/build/src/index.js > /tmp/wjb.log 2>&1 &
             for _ in $(seq 1 30); do curl -sf "http://localhost:7000/book?type=Forum" >/dev/null && break; sleep 2; done
+            cat /tmp/wjb.log || true
             # Seed several Forum rows so the table renders (and scrolls).
             node test/e2e/seed-news.mjs seed
-            echo "DIAG backend Forum rows:"; curl -s "http://localhost:7000/book?type=Forum" | head -c 300; echo
-            echo "DIAG web-jam-back startup log:"; cat /tmp/wjb.log
             # Point the frontend at the local backend. Vite reads BackendUrl from
             # a .env file (loadEnv), and .env is gitignored so CI has none — write
             # it here, else the build bakes an empty BackendUrl and the browser

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,9 @@ jobs:
             NODE_ENV=production npm run build
             PORT=7777 node server.mjs > /tmp/front.log 2>&1 &
             sleep 5
+            echo "DIAG post-seed backend rows:"; curl -s "http://localhost:7000/book?type=Forum" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{console.log(JSON.parse(d).length)}catch(e){console.log('parse-fail:'+d.slice(0,80))}})" || true
+            echo "DIAG CORS for origin 7777:"; curl -s -H "Origin: http://localhost:7777" -D - -o /dev/null "http://localhost:7000/book?type=Forum" | grep -i "access-control" || echo "NO access-control header"
+            echo "DIAG bundle BackendUrl baked:"; grep -ho "http://localhost:7000" dist/assets/*.js | head -1 || echo "localhost:7000 NOT in bundle"
             set +e
             E2E_SEEDED=1 BASE_URL=http://localhost:7777 npm run test:e2e
             STATUS=$?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.17",
+      "version": "2.1.18",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.16",
+      "version": "2.1.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.14",
+      "version": "2.1.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.13",
+      "version": "2.1.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -61,6 +61,7 @@
         "eslint-plugin-security": "^4.0.0",
         "globals": "^15.14.0",
         "jsdom": "^29.1.1",
+        "mongodb": "^7.2.0",
         "stylelint": "^17.0.0",
         "stylelint-config-recommended-scss": "^17.0.1",
         "stylelint-config-standard": "^40.0.0",
@@ -1094,6 +1095,16 @@
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+      "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "9.0.1",
@@ -2426,6 +2437,23 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
@@ -3454,6 +3482,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bson": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
+      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/bytes": {
@@ -6114,6 +6152,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/meow": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
@@ -6225,6 +6270,104 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
+      "integrity": "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ms": {
@@ -7604,6 +7747,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/stable-hash-x": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.15",
+      "version": "2.1.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.18",
+      "version": "2.1.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {
@@ -98,6 +98,7 @@
     "eslint-plugin-security": "^4.0.0",
     "globals": "^15.14.0",
     "jsdom": "^29.1.1",
+    "mongodb": "^7.2.0",
     "stylelint": "^17.0.0",
     "stylelint-config-recommended-scss": "^17.0.1",
     "stylelint-config-standard": "^40.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/News/NewsContent.tsx
+++ b/src/containers/News/NewsContent.tsx
@@ -1,28 +1,46 @@
 import type { Ibook } from 'src/providers/utils';
-import { useElementHeight } from 'src/lib/useWindowSize';
 import {
-  useContext, useEffect, useState,
+  useContext, useEffect, useRef, useState,
 } from 'react';
 import { AuthContext } from 'src/providers/Auth.provider';
 import { checkIsAdmin } from 'src/App';
-import { Button } from '@mui/material';
 import ELCALogo from 'src/components/elcaLogo';
 import { EditNewsDialog } from './EditNewsDialog';
 import { defaultNews } from './utilsN';
 
-export function SignUpForEmails({ height }:{ height:number }) {
+// The email sign-up is a Constant Contact inline form injected by an external
+// script (see index.html). Firefox's Enhanced Tracking Protection blocks that
+// script, so the div stays empty and no form appears. We can't link a direct
+// sign-up URL (we don't have one), so when the form fails to render we show a
+// fallback asking people to contact the office. Detection: if the CTCT div is
+// still empty a few seconds after mount, the script was blocked/failed.
+export function SignUpForEmails() {
+  const formRef = useRef<HTMLDivElement>(null);
+  const [unavailable, setUnavailable] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (formRef.current && formRef.current.childElementCount === 0) setUnavailable(true);
+    }, 3500);
+    return () => clearTimeout(timer);
+  }, []);
   return (
     <>
-      {height < 700 ? (
-        <Button
-          onClick={() => window.location.reload()}
-          size="large"
-          variant="contained"
-        >
-          Sign Up for Emails
-        </Button>
+      <div ref={formRef} className="ctct-inline-form" data-form-id="99081bd2-b1a5-48cd-bb60-8c9aba82c2a4" />
+      {unavailable ? (
+        <div className="signup-unavailable">
+          <p>
+            Our email sign-up form isn&rsquo;t available in this browser. To join our
+            email list, please contact the church office (Sandi Roop) at
+            {' '}
+            <a href="tel:+15403894963">(540) 389-4963</a>
+            {' '}
+            or
+            {' '}
+            <a href="mailto:office1@collegelutheran.org">office1@collegelutheran.org</a>
+            , and she will add you to the distribution list.
+          </p>
+        </div>
       ) : null}
-      <div className="ctct-inline-form" data-form-id="99081bd2-b1a5-48cd-bb60-8c9aba82c2a4" />
     </>
   );
 }
@@ -31,7 +49,6 @@ interface NewsContentProps {
   books?: Ibook[];
 }
 export function NewsContent({ books }: NewsContentProps) {
-  const { height, ref } = useElementHeight<HTMLDivElement>();
   const { auth } = useContext(AuthContext);
   const [isAdmin, setIsAdmin] = useState(false);
   const [editNews, setEditNews] = useState(defaultNews);
@@ -89,8 +106,8 @@ export function NewsContent({ books }: NewsContentProps) {
         </div>
         <p style={{ fontSize: '4pt', margin: '0' }}>&nbsp;</p>
         <hr style={{ margin: '0px' }} />
-        <div ref={ref} style={{ margin: 'auto', textAlign: 'center', marginTop: '-30px' }}>
-          <SignUpForEmails height={height || 100} />
+        <div style={{ margin: 'auto', textAlign: 'center' }}>
+          <SignUpForEmails />
         </div>
       </div>
       <EditNewsDialog editNews={editNews} setEditNews={setEditNews} />

--- a/src/styles/_news.scss
+++ b/src/styles/_news.scss
@@ -53,3 +53,14 @@
     width: 320px !important;
   }
 }
+
+// Fallback shown when the Constant Contact sign-up form is blocked (Firefox
+// Enhanced Tracking Protection) and never renders into .ctct-inline-form.
+.signup-unavailable {
+  max-width: 32rem;
+  margin: 1rem auto;
+  padding: 0 1rem;
+  color: #444;
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
+++ b/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
@@ -20,13 +20,8 @@ exports[`NewsContent > renders the news page 1`] = `
         style="margin: 0px;"
       />
       <div
-        style="text-align: center; margin: -30px auto auto;"
+        style="margin: auto; text-align: center;"
       >
-        <button
-          variant="contained"
-        >
-          Sign Up for Emails
-        </button>
         <div
           class="ctct-inline-form"
           data-form-id="99081bd2-b1a5-48cd-bb60-8c9aba82c2a4"

--- a/test/e2e/news-signup.spec.ts
+++ b/test/e2e/news-signup.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+// Guards the News-page email sign-up fallback. The sign-up is a Constant Contact
+// inline form injected by an external script (signup-form-widget.min.js). Firefox
+// Enhanced Tracking Protection blocks that script, leaving the form empty — what
+// Pastor David reported. We simulate the block by aborting the script request,
+// which is deterministic across browsers, then assert the contact-the-office
+// fallback appears and the old floating "Sign Up for Emails" reload button is
+// gone. Runs on desktop + mobile (see playwright.config.ts projects).
+
+test('shows the contact-the-office fallback when the sign-up form is blocked', async ({ page }) => {
+  await page.route('**/signup-form-widget*', (route) => route.abort());
+  await page.goto('/news', { waitUntil: 'domcontentloaded' });
+
+  // Fallback appears after the component's empty-form detection timeout.
+  // Scope to the fallback container — the office email/phone also appear in the
+  // site sidebar, so page-wide selectors would be ambiguous.
+  const fallback = page.locator('.signup-unavailable');
+  await expect(fallback).toBeVisible({ timeout: 12_000 });
+  await expect(fallback).toContainText(/contact the church office/i);
+  await expect(fallback).toContainText('Sandi Roop');
+  await expect(fallback.getByRole('link', { name: 'office1@collegelutheran.org' })).toBeVisible();
+  await expect(fallback.getByRole('link', { name: '(540) 389-4963' })).toBeVisible();
+
+  // The old reload button that floated over the News table must be gone.
+  await expect(page.getByRole('button', { name: 'Sign Up for Emails' })).toHaveCount(0);
+});
+
+test('does not show the fallback when the form renders', async ({ page }) => {
+  await page.goto('/news', { waitUntil: 'domcontentloaded' });
+
+  // Simulate a successful Constant Contact injection: give the form div a child
+  // before the detection timeout fires.
+  // Scope to the React-rendered target (the real form GUID); index.html also
+  // has a vestigial .ctct-inline-form, so the bare class is ambiguous.
+  const formId = '99081bd2-b1a5-48cd-bb60-8c9aba82c2a4';
+  await page.locator(`[data-form-id="${formId}"]`).waitFor({ state: 'attached' });
+  await page.evaluate((id) => {
+    const el = document.querySelector(`[data-form-id="${id}"]`);
+    if (el) el.innerHTML = '<form data-stub="1"><input aria-label="email" /></form>';
+  }, formId);
+
+  // Wait past the detection window, then confirm no fallback rendered.
+  await page.waitForTimeout(4500);
+  await expect(page.getByText(/contact the church office/i)).toHaveCount(0);
+});

--- a/test/e2e/news-signup.spec.ts
+++ b/test/e2e/news-signup.spec.ts
@@ -27,20 +27,27 @@ test('shows the contact-the-office fallback when the sign-up form is blocked', a
 });
 
 test('does not show the fallback when the form renders', async ({ page }) => {
-  await page.goto('/news', { waitUntil: 'domcontentloaded' });
-
-  // Simulate a successful Constant Contact injection: give the form div a child
-  // before the detection timeout fires.
-  // Scope to the React-rendered target (the real form GUID); index.html also
-  // has a vestigial .ctct-inline-form, so the bare class is ambiguous.
+  // Simulate a successful Constant Contact injection deterministically: fill the
+  // React-rendered target (the real form GUID; index.html also has a vestigial
+  // .ctct-inline-form) the instant it is added to the DOM, before the component's
+  // empty-div detection timeout. addInitScript + MutationObserver avoids a race
+  // on slow CI where the 3.5s timeout could otherwise fire first.
   const formId = '99081bd2-b1a5-48cd-bb60-8c9aba82c2a4';
-  await page.locator(`[data-form-id="${formId}"]`).waitFor({ state: 'attached' });
-  await page.evaluate((id) => {
-    const el = document.querySelector(`[data-form-id="${id}"]`);
-    if (el) el.innerHTML = '<form data-stub="1"><input aria-label="email" /></form>';
+  await page.addInitScript((id) => {
+    const fill = () => {
+      const el = document.querySelector(`[data-form-id="${id}"]`);
+      if (el && el.childElementCount === 0) {
+        el.innerHTML = '<form data-stub="1"><input aria-label="email" /></form>';
+        return true;
+      }
+      return false;
+    };
+    const obs = new MutationObserver(() => { if (fill()) obs.disconnect(); });
+    obs.observe(document.documentElement, { childList: true, subtree: true });
   }, formId);
 
+  await page.goto('/news', { waitUntil: 'domcontentloaded' });
   // Wait past the detection window, then confirm no fallback rendered.
   await page.waitForTimeout(4500);
-  await expect(page.getByText(/contact the church office/i)).toHaveCount(0);
+  await expect(page.locator('.signup-unavailable')).toHaveCount(0);
 });

--- a/test/e2e/news-table.spec.ts
+++ b/test/e2e/news-table.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+// Real-API integration test for the News table. In CI the frontend is built with
+// BackendUrl pointing at a live web-jam-back running on the test MongoDB, which
+// has been seeded with several "Forum" rows (test/e2e/seed-news.mjs). Here we
+// assert those real rows render in the table and that the table fits the
+// viewport (no horizontal overflow) on both desktop and mobile — exercising the
+// scrolling/overflow behaviour with a full table.
+//
+// Only runs in the seeded integration context (E2E_SEEDED=1). Skipped for plain
+// runs against prod/other backends, which won't have the seeded rows.
+
+test.describe('News table (real API + seeded test DB)', () => {
+  test.skip(process.env.E2E_SEEDED !== '1', 'requires the seeded test-DB backend (CI e2e job)');
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/news', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('renders seeded news rows from the API', async ({ page }) => {
+    // A specific seeded row proves the data round-tripped through the real API.
+    await expect(page.getByRole('link', { name: 'E2E Test News Item 01' })).toBeVisible({ timeout: 15_000 });
+    const rows = page.locator('table.newsTable tbody tr');
+    expect(await rows.count()).toBeGreaterThanOrEqual(10);
+  });
+
+  test('the news table does not overflow the viewport', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'E2E Test News Item 01' })).toBeVisible({ timeout: 15_000 });
+    const overflow = await page.evaluate(() => {
+      const el = document.scrollingElement || document.documentElement;
+      return el.scrollWidth - el.clientWidth;
+    });
+    expect(overflow, `unexpected horizontal overflow of ${overflow}px`).toBeLessThanOrEqual(2);
+  });
+});

--- a/test/e2e/seed-news.mjs
+++ b/test/e2e/seed-news.mjs
@@ -1,0 +1,45 @@
+/* global process, console */
+// Seeds / removes News (type:"Forum") rows in the test MongoDB for the news-table
+// e2e. Used by the CircleCI e2e job: `seed` before the run, `cleanup` after
+// (always). Connects with MONGO_DB_URI (the TEST db — never prod). All seeded
+// rows carry a unique marker so cleanup removes exactly what we added.
+import { MongoClient } from 'mongodb';
+
+const uri = process.env.MONGO_DB_URI;
+const MARKER = 'E2E_NEWS_SEED';
+// Enough rows that the News table must scroll, so the e2e also exercises
+// overflow/scrolling on both desktop and mobile.
+const COUNT = 15;
+
+async function run() {
+  const mode = process.argv[2];
+  if (!uri) { console.error('MONGO_DB_URI is not set'); process.exit(1); }
+  if (mode !== 'seed' && mode !== 'cleanup') {
+    console.error('usage: node seed-news.mjs seed|cleanup');
+    process.exit(1);
+  }
+  const client = new MongoClient(uri);
+  await client.connect();
+  try {
+    const books = client.db().collection('books');
+    if (mode === 'seed') {
+      const now = Date.now();
+      const docs = Array.from({ length: COUNT }, (_, i) => ({
+        type: 'Forum',
+        seedMarker: MARKER,
+        title: `E2E Test News Item ${String(i + 1).padStart(2, '0')}`,
+        url: 'https://www.collegelutheran.org/',
+        created_at: new Date(now - i * 86_400_000).toISOString(),
+      }));
+      await books.insertMany(docs);
+      console.log(`seeded ${docs.length} Forum news rows`);
+    } else {
+      const res = await books.deleteMany({ seedMarker: MARKER });
+      console.log(`removed ${res.deletedCount} seeded rows`);
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+run().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Problem
Pastor David reported the News-page **email sign-up doesn't work in Firefox**. The sign-up is a Constant Contact inline form injected by an external script (`signup-form-widget.min.js`); Firefox's **Enhanced Tracking Protection blocks Constant Contact**, so the form never renders and the page just shows an empty area. We have no direct sign-up URL to link as a fallback.

## Fix
- **Detect non-render → graceful fallback.** If the CTCT target div is still empty ~3.5s after mount (script blocked/failed), show a message asking people to contact the church office (**Sandi Roop**) by phone `(540) 389-4963` or email `office1@collegelutheran.org` to be added to the list.
- **Remove the floating reload button.** The old `height < 700` "Sign Up for Emails" button (a reload hack) was floating over the News table; removed it and its negative-margin wrapper. Same root cause as the report.

## Tests — Playwright (desktop + mobile)
- **`news-signup.spec`** — aborts the CTCT script to deterministically simulate the Firefox block, asserts the fallback renders (scoped to `.signup-unavailable`, since the office contact also appears in the sidebar) and the floating button is gone; plus a positive path that confirms no fallback when the form renders.
- **`news-table.spec`** — **real API, no stubs** (per request). CI starts a real **web-jam-back** (public repo: cloned, `npm ci --ignore-scripts`, `tsc`) against the **TEST MongoDB**, seeds several `Forum` rows, builds the frontend pointed at the local backend (`BackendUrl=http://localhost:7000`, `AllowUrl` set for CORS), and asserts the seeded rows render and the table fits the viewport (exercises overflow/scroll). Seeded rows are removed afterward (always, pass or fail). Guarded by `E2E_SEEDED=1` so it only runs in that context.
- **CircleCI e2e job rewired** for the above (builds with `NODE_ENV=production` so React uses the prod JSX runtime).

## ⚠️ Action required before CI passes
Add a **`MONGO_DB_URI`** project env var in CircleCI pointing at the **TEST database** (never prod). The seed/teardown and the test backend use it.

## How to Test Locally
```bash
git checkout fix-cl-news-signup-fallback && npm install
# sign-up fallback (no backend needed):
npm run dev   # then in another shell:
BASE_URL=http://localhost:7777 npx playwright test news-signup.spec.ts
# full real-DB flow (validated this way):
docker run -d --name m -p 27018:27017 mongo:7
MONGO_DB_URI=mongodb://localhost:27018/cltest node test/e2e/seed-news.mjs seed
# build+start web-jam-back against that DB on :7000 (AllowUrl localhost:7777), then:
NODE_ENV=production BackendUrl=http://localhost:7000 npm run build
PORT=7777 node server.mjs &
E2E_SEEDED=1 BASE_URL=http://localhost:7777 npm run test:e2e
MONGO_DB_URI=mongodb://localhost:27018/cltest node test/e2e/seed-news.mjs cleanup
```
Locally validated end-to-end: 22 passed, 2 skipped; teardown removed all 15 seeded rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)