### PR TITLE
fix(news): remove broken Constant Contact widget; keep office-contact sign-up

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,14 +20,6 @@
 </head>
 
 <body>
-  <!-- Target for Constant Contact inline signup form widget - adding id for better lookup -->
-  <div id="ctct-inline-form" class="ctct-inline-form" data-form-id="Inline Form Created 2022/07/09, 12:42:54 PM">
-    <noscript>
-      <p>To sign up for our newsletter, please <a
-          href="https://visitor.r20.constantcontact.com/manage/optin?v=001cd950f6ed99253e212302d6c939739">click
-          here</a>.</p>
-    </noscript>
-  </div>
   <div id="root">
     <div class="splash">
       <div class="message">College Lutheran Church</div>
@@ -35,13 +27,6 @@
     </div>
   </div>
   <script type="module" src="/src/Main.tsx"></script>
-  <!-- Begin Constant Contact Active Forms - moved to bottom to ensure div is present -->
-  <script>
-    var _ctct_m = "01cd950f6ed99253e212302d6c939739";
-  </script>
-  <script id="signupScript" src="https://static.ctctcdn.com/js/signup-form-widget/current/signup-form-widget.min.js"
-    async defer></script>
-  <!-- End Constant Contact Active Forms -->
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.19",
+      "version": "2.1.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/News/NewsContent.tsx
+++ b/src/containers/News/NewsContent.tsx
@@ -8,23 +8,24 @@ import ELCALogo from 'src/components/elcaLogo';
 import { EditNewsDialog } from './EditNewsDialog';
 import { defaultNews } from './utilsN';
 
-// Constant Contact's hosted opt-in page. We link to it instead of embedding the
-// inline-form widget: the widget was injected by an external script that
-// Firefox's Enhanced Tracking Protection blocks (form never rendered), and it
-// also raced the SPA route mount. A direct link works in every browser with no
-// script, no timing race, and no console errors.
-const OPT_IN_URL = 'https://visitor.r20.constantcontact.com/manage/optin?v=001cd950f6ed99253e212302d6c939739';
-
+// Email sign-up is handled by the church office, not an online form. The old
+// Constant Contact inline-form widget never worked (Firefox blocked the script,
+// it raced the SPA mount, and there is no usable hosted form/URL to link to), so
+// we simply ask people to contact the office to be added to the list.
 export function SignUpForEmails() {
   return (
-    <a
-      className="signup-link"
-      href={OPT_IN_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      Sign Up for Email Updates
-    </a>
+    <div className="signup-info">
+      <p>
+        To join our email list, please contact the church office (Sandi Roop) at
+        {' '}
+        <a href="tel:+15403894963">(540) 389-4963</a>
+        {' '}
+        or
+        {' '}
+        <a href="mailto:office1@collegelutheran.org">office1@collegelutheran.org</a>
+        , and she will add you to the distribution list.
+      </p>
+    </div>
   );
 }
 

--- a/src/containers/News/NewsContent.tsx
+++ b/src/containers/News/NewsContent.tsx
@@ -1,6 +1,6 @@
 import type { Ibook } from 'src/providers/utils';
 import {
-  useContext, useEffect, useRef, useState,
+  useContext, useEffect, useState,
 } from 'react';
 import { AuthContext } from 'src/providers/Auth.provider';
 import { checkIsAdmin } from 'src/App';
@@ -8,40 +8,23 @@ import ELCALogo from 'src/components/elcaLogo';
 import { EditNewsDialog } from './EditNewsDialog';
 import { defaultNews } from './utilsN';
 
-// The email sign-up is a Constant Contact inline form injected by an external
-// script (see index.html). Firefox's Enhanced Tracking Protection blocks that
-// script, so the div stays empty and no form appears. We can't link a direct
-// sign-up URL (we don't have one), so when the form fails to render we show a
-// fallback asking people to contact the office. Detection: if the CTCT div is
-// still empty a few seconds after mount, the script was blocked/failed.
+// Constant Contact's hosted opt-in page. We link to it instead of embedding the
+// inline-form widget: the widget was injected by an external script that
+// Firefox's Enhanced Tracking Protection blocks (form never rendered), and it
+// also raced the SPA route mount. A direct link works in every browser with no
+// script, no timing race, and no console errors.
+const OPT_IN_URL = 'https://visitor.r20.constantcontact.com/manage/optin?v=001cd950f6ed99253e212302d6c939739';
+
 export function SignUpForEmails() {
-  const formRef = useRef<HTMLDivElement>(null);
-  const [unavailable, setUnavailable] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (formRef.current && formRef.current.childElementCount === 0) setUnavailable(true);
-    }, 3500);
-    return () => clearTimeout(timer);
-  }, []);
   return (
-    <>
-      <div ref={formRef} className="ctct-inline-form" data-form-id="99081bd2-b1a5-48cd-bb60-8c9aba82c2a4" />
-      {unavailable ? (
-        <div className="signup-unavailable">
-          <p>
-            Our email sign-up form isn&rsquo;t available in this browser. To join our
-            email list, please contact the church office (Sandi Roop) at
-            {' '}
-            <a href="tel:+15403894963">(540) 389-4963</a>
-            {' '}
-            or
-            {' '}
-            <a href="mailto:office1@collegelutheran.org">office1@collegelutheran.org</a>
-            , and she will add you to the distribution list.
-          </p>
-        </div>
-      ) : null}
-    </>
+    <a
+      className="signup-link"
+      href={OPT_IN_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Sign Up for Email Updates
+    </a>
   );
 }
 

--- a/src/styles/_news.scss
+++ b/src/styles/_news.scss
@@ -54,13 +54,22 @@
   }
 }
 
-// Fallback shown when the Constant Contact sign-up form is blocked (Firefox
-// Enhanced Tracking Protection) and never renders into .ctct-inline-form.
-.signup-unavailable {
-  max-width: 32rem;
+// Button-style link to Constant Contact's hosted opt-in page (replaces the old
+// embedded inline-form widget; see NewsContent.tsx).
+.signup-link {
+  display: inline-block;
   margin: 1rem auto;
-  padding: 0 1rem;
-  color: #444;
+  padding: 0.6rem 1.4rem;
+  background: #4a148c;
+  color: #fff;
+  border-radius: 4px;
   font-size: 1rem;
-  line-height: 1.5;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    background: #6a1b9a;
+    text-decoration: none;
+  }
 }

--- a/src/styles/_news.scss
+++ b/src/styles/_news.scss
@@ -54,22 +54,13 @@
   }
 }
 
-// Button-style link to Constant Contact's hosted opt-in page (replaces the old
-// embedded inline-form widget; see NewsContent.tsx).
-.signup-link {
-  display: inline-block;
+// Email sign-up is handled by the church office (no online form); see
+// NewsContent.tsx.
+.signup-info {
+  max-width: 32rem;
   margin: 1rem auto;
-  padding: 0.6rem 1.4rem;
-  background: #4a148c;
-  color: #fff;
-  border-radius: 4px;
+  padding: 0 1rem;
+  color: #444;
   font-size: 1rem;
-  font-weight: 600;
-  text-decoration: none;
-
-  &:hover,
-  &:focus {
-    background: #6a1b9a;
-    text-decoration: none;
-  }
+  line-height: 1.5;
 }

--- a/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
+++ b/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
@@ -22,10 +22,14 @@ exports[`NewsContent > renders the news page 1`] = `
       <div
         style="margin: auto; text-align: center;"
       >
-        <div
-          class="ctct-inline-form"
-          data-form-id="99081bd2-b1a5-48cd-bb60-8c9aba82c2a4"
-        />
+        <a
+          class="signup-link"
+          href="https://visitor.r20.constantcontact.com/manage/optin?v=001cd950f6ed99253e212302d6c939739"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Sign Up for Email Updates
+        </a>
       </div>
     </div>
     <div

--- a/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
+++ b/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
@@ -22,14 +22,28 @@ exports[`NewsContent > renders the news page 1`] = `
       <div
         style="margin: auto; text-align: center;"
       >
-        <a
-          class="signup-link"
-          href="https://visitor.r20.constantcontact.com/manage/optin?v=001cd950f6ed99253e212302d6c939739"
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          class="signup-info"
         >
-          Sign Up for Email Updates
-        </a>
+          <p>
+            To join our email list, please contact the church office (Sandi Roop) at
+             
+            <a
+              href="tel:+15403894963"
+            >
+              (540) 389-4963
+            </a>
+             
+            or
+             
+            <a
+              href="mailto:office1@collegelutheran.org"
+            >
+              office1@collegelutheran.org
+            </a>
+            , and she will add you to the distribution list.
+          </p>
+        </div>
       </div>
     </div>
     <div

--- a/test/e2e/news-signup.spec.ts
+++ b/test/e2e/news-signup.spec.ts
@@ -1,53 +1,25 @@
 import { test, expect } from '@playwright/test';
 
-// Guards the News-page email sign-up fallback. The sign-up is a Constant Contact
-// inline form injected by an external script (signup-form-widget.min.js). Firefox
-// Enhanced Tracking Protection blocks that script, leaving the form empty — what
-// Pastor David reported. We simulate the block by aborting the script request,
-// which is deterministic across browsers, then assert the contact-the-office
-// fallback appears and the old floating "Sign Up for Emails" reload button is
-// gone. Runs on desktop + mobile (see playwright.config.ts projects).
+// Guards the News-page email sign-up. We dropped the Constant Contact inline-form
+// widget (an external script Firefox Enhanced Tracking Protection blocked, which
+// also raced the SPA route mount) in favour of a plain link to Constant Contact's
+// hosted opt-in page. This works in every browser with no script and no console
+// errors. Runs on desktop + mobile (see playwright.config.ts projects).
 
-test('shows the contact-the-office fallback when the sign-up form is blocked', async ({ page }) => {
-  await page.route('**/signup-form-widget*', (route) => route.abort());
+const OPT_IN_URL = 'https://visitor.r20.constantcontact.com/manage/optin?v=001cd950f6ed99253e212302d6c939739';
+
+test('shows a sign-up link to the hosted opt-in page', async ({ page }) => {
   await page.goto('/news', { waitUntil: 'domcontentloaded' });
 
-  // Fallback appears after the component's empty-form detection timeout.
-  // Scope to the fallback container — the office email/phone also appear in the
-  // site sidebar, so page-wide selectors would be ambiguous.
-  const fallback = page.locator('.signup-unavailable');
-  await expect(fallback).toBeVisible({ timeout: 12_000 });
-  await expect(fallback).toContainText(/contact the church office/i);
-  await expect(fallback).toContainText('Sandi Roop');
-  await expect(fallback.getByRole('link', { name: 'office1@collegelutheran.org' })).toBeVisible();
-  await expect(fallback.getByRole('link', { name: '(540) 389-4963' })).toBeVisible();
+  const link = page.getByRole('link', { name: 'Sign Up for Email Updates' });
+  await expect(link).toBeVisible();
+  await expect(link).toHaveAttribute('href', OPT_IN_URL);
+  await expect(link).toHaveAttribute('target', '_blank');
+  await expect(link).toHaveAttribute('rel', /noopener/);
 
-  // The old reload button that floated over the News table must be gone.
-  await expect(page.getByRole('button', { name: 'Sign Up for Emails' })).toHaveCount(0);
-});
-
-test('does not show the fallback when the form renders', async ({ page }) => {
-  // Simulate a successful Constant Contact injection deterministically: fill the
-  // React-rendered target (the real form GUID; index.html also has a vestigial
-  // .ctct-inline-form) the instant it is added to the DOM, before the component's
-  // empty-div detection timeout. addInitScript + MutationObserver avoids a race
-  // on slow CI where the 3.5s timeout could otherwise fire first.
-  const formId = '99081bd2-b1a5-48cd-bb60-8c9aba82c2a4';
-  await page.addInitScript((id) => {
-    const fill = () => {
-      const el = document.querySelector(`[data-form-id="${id}"]`);
-      if (el && el.childElementCount === 0) {
-        el.innerHTML = '<form data-stub="1"><input aria-label="email" /></form>';
-        return true;
-      }
-      return false;
-    };
-    const obs = new MutationObserver(() => { if (fill()) obs.disconnect(); });
-    obs.observe(document.documentElement, { childList: true, subtree: true });
-  }, formId);
-
-  await page.goto('/news', { waitUntil: 'domcontentloaded' });
-  // Wait past the detection window, then confirm no fallback rendered.
-  await page.waitForTimeout(4500);
+  // The retired widget, its empty-form fallback, and the old reload button must
+  // all be gone.
+  await expect(page.locator('.ctct-inline-form')).toHaveCount(0);
   await expect(page.locator('.signup-unavailable')).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Sign Up for Emails' })).toHaveCount(0);
 });

--- a/test/e2e/news-signup.spec.ts
+++ b/test/e2e/news-signup.spec.ts
@@ -1,25 +1,22 @@
 import { test, expect } from '@playwright/test';
 
-// Guards the News-page email sign-up. We dropped the Constant Contact inline-form
-// widget (an external script Firefox Enhanced Tracking Protection blocked, which
-// also raced the SPA route mount) in favour of a plain link to Constant Contact's
-// hosted opt-in page. This works in every browser with no script and no console
-// errors. Runs on desktop + mobile (see playwright.config.ts projects).
+// Guards the News-page email sign-up. There is no working online form: the old
+// Constant Contact inline-form widget never rendered (Firefox blocked the script,
+// it raced the SPA mount, and there is no usable hosted form/URL), so the page
+// just asks people to contact the church office. Runs on desktop + mobile (see
+// playwright.config.ts projects).
 
-const OPT_IN_URL = 'https://visitor.r20.constantcontact.com/manage/optin?v=001cd950f6ed99253e212302d6c939739';
-
-test('shows a sign-up link to the hosted opt-in page', async ({ page }) => {
+test('shows the contact-the-office email sign-up info', async ({ page }) => {
   await page.goto('/news', { waitUntil: 'domcontentloaded' });
 
-  const link = page.getByRole('link', { name: 'Sign Up for Email Updates' });
-  await expect(link).toBeVisible();
-  await expect(link).toHaveAttribute('href', OPT_IN_URL);
-  await expect(link).toHaveAttribute('target', '_blank');
-  await expect(link).toHaveAttribute('rel', /noopener/);
+  const info = page.locator('.signup-info');
+  await expect(info).toBeVisible();
+  await expect(info).toContainText(/contact the church office/i);
+  await expect(info).toContainText('Sandi Roop');
+  await expect(info.getByRole('link', { name: 'office1@collegelutheran.org' })).toBeVisible();
+  await expect(info.getByRole('link', { name: '(540) 389-4963' })).toBeVisible();
 
-  // The retired widget, its empty-form fallback, and the old reload button must
-  // all be gone.
+  // The retired Constant Contact widget and its old reload button must be gone.
   await expect(page.locator('.ctct-inline-form')).toHaveCount(0);
-  await expect(page.locator('.signup-unavailable')).toHaveCount(0);
   await expect(page.getByRole('button', { name: 'Sign Up for Emails' })).toHaveCount(0);
 });


### PR DESCRIPTION
## What

The News-page email sign-up never worked. Constant Contact's inline-form widget required an external script that Firefox Enhanced Tracking Protection blocked, and it also raced the SPA route mount — so the form rendered for no one. There is no usable hosted Constant Contact form or URL to link to either (the only URL ever saved was a malformed `optin?v=001...` that lands on `error_corrupted_param.jsp`).

So this removes the widget entirely and makes the **contact-the-church-office** text the permanent sign-up: people call or email the office (Sandi Roop) to be added to the list. No external script, no SPA timing race, no console errors.

## Changes
- `index.html` — remove the CTCT widget script + both stray `.ctct-inline-form` divs
- `src/containers/News/NewsContent.tsx` — `SignUpForEmails` now always shows the office-contact info (was a 3.5s empty-form fallback)
- `src/styles/_news.scss` — `.signup-unavailable` → `.signup-info`
- `test/e2e/news-signup.spec.ts` — assert the office-contact info shows and the widget is gone
- snapshot + version bump (2.1.19 → 2.1.20)

## How to Test Locally
```bash
cd /home/joshua/WebJamApps/CollegeLutheran
git checkout news-signup-hosted-link
npm ci
npm test                 # unit suite (48 files / 130 tests)
npm run dev              # then open http://localhost:<port>/news
```
On the News page, confirm the "To join our email list, please contact the church office (Sandi Roop)…" text appears below the news table with working phone + email links. Open DevTools console — the `Div for inline form ... is missing` error should be gone. (Remaining Facebook-iframe console noise on the homepage is unrelated and pre-existing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)