### PR TITLE
fix(news): load Constant Contact widget only on the News page (kills console error)

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,14 +20,6 @@
 </head>
 
 <body>
-  <!-- Target for Constant Contact inline signup form widget - adding id for better lookup -->
-  <div id="ctct-inline-form" class="ctct-inline-form" data-form-id="Inline Form Created 2022/07/09, 12:42:54 PM">
-    <noscript>
-      <p>To sign up for our newsletter, please <a
-          href="https://visitor.r20.constantcontact.com/manage/optin?v=001cd950f6ed99253e212302d6c939739">click
-          here</a>.</p>
-    </noscript>
-  </div>
   <div id="root">
     <div class="splash">
       <div class="message">College Lutheran Church</div>
@@ -35,13 +27,6 @@
     </div>
   </div>
   <script type="module" src="/src/Main.tsx"></script>
-  <!-- Begin Constant Contact Active Forms - moved to bottom to ensure div is present -->
-  <script>
-    var _ctct_m = "01cd950f6ed99253e212302d6c939739";
-  </script>
-  <script id="signupScript" src="https://static.ctctcdn.com/js/signup-form-widget/current/signup-form-widget.min.js"
-    async defer></script>
-  <!-- End Constant Contact Active Forms -->
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.19",
+      "version": "2.1.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/News/NewsContent.tsx
+++ b/src/containers/News/NewsContent.tsx
@@ -18,6 +18,18 @@ export function SignUpForEmails() {
   const formRef = useRef<HTMLDivElement>(null);
   const [unavailable, setUnavailable] = useState(false);
   useEffect(() => {
+    // Load the Constant Contact widget here, on the only page that has its target
+    // div. Loading it globally from index.html made the widget log "Div for inline
+    // form ... is missing" on every other page, none of which has a div for it.
+    (window as unknown as { _ctct_m?: string })._ctct_m = '01cd950f6ed99253e212302d6c939739';
+    if (!document.getElementById('ctctSignupScript')) {
+      const s = document.createElement('script');
+      s.id = 'ctctSignupScript';
+      s.src = 'https://static.ctctcdn.com/js/signup-form-widget/current/signup-form-widget.min.js';
+      s.async = true;
+      s.defer = true;
+      document.body.appendChild(s);
+    }
     const timer = setTimeout(() => {
       if (formRef.current && formRef.current.childElementCount === 0) setUnavailable(true);
     }, 3500);

--- a/test/e2e/news-signup.spec.ts
+++ b/test/e2e/news-signup.spec.ts
@@ -28,10 +28,10 @@ test('shows the contact-the-office fallback when the sign-up form is blocked', a
 
 test('does not show the fallback when the form renders', async ({ page }) => {
   // Simulate a successful Constant Contact injection deterministically: fill the
-  // React-rendered target (the real form GUID; index.html also has a vestigial
-  // .ctct-inline-form) the instant it is added to the DOM, before the component's
-  // empty-div detection timeout. addInitScript + MutationObserver avoids a race
-  // on slow CI where the 3.5s timeout could otherwise fire first.
+  // React-rendered target (the real form GUID) the instant it is added to the
+  // DOM, before the component's empty-div detection timeout. addInitScript +
+  // MutationObserver avoids a race on slow CI where the 3.5s timeout could
+  // otherwise fire first.
   const formId = '99081bd2-b1a5-48cd-bb60-8c9aba82c2a4';
   await page.addInitScript((id) => {
     const fill = () => {


### PR DESCRIPTION
## What

The console error `Div for inline form "Inline Form Created 2022/07/09, 12:42:54 PM" is missing. Was inline code installed?` was firing on every page **except** `/news`.

Root cause: the Constant Contact widget script was loaded **globally** from `index.html`, but its target form div (`data-form-id="99081bd2…"`) only exists on the News page. On every other page the widget activates, can't find a div for the configured form, and logs the "missing" error. It first reached production with this morning's deploy (the static div + global script came from the May 23 `bd94ad0` "console log fixes" commit).

Fix: load the widget script from `SignUpForEmails` (the News component) so it only runs where its div lives. The real form still renders on `/news`, and the contact-the-office (Sandi Roop) fallback still covers browsers that block the script (Firefox ETP). Also removed the stray static `.ctct-inline-form` div from `index.html`.

## Verified (headless-browser console capture)

| | before | after |
|---|---|---|
| `/` — CTCT "missing" error | 1 | **0** |
| `/news` — CTCT error | 0 | **0** |
| `/news` — real form renders (target div populated) | — | **yes** |

The remaining console noise on the homepage is the embedded **Facebook Page Plugin iframe** (`Could not find element "u_1_…"`, `DataStore.get`, Permissions-Policy `unload`/`bluetooth`). That is Facebook's own code inside their iframe — unrelated to this change and not fixable from our side. Happy to discuss removing/replacing the FB feed separately if you want those gone.

## Changes
- `index.html` — remove the global CTCT script + the stray static `.ctct-inline-form` div
- `src/containers/News/NewsContent.tsx` — `SignUpForEmails` injects the widget script on mount (guarded so it loads once)
- `test/e2e/news-signup.spec.ts` — drop a stale comment about the removed static div
- version bump 2.1.19 → 2.1.20

## How to Test Locally
```bash
cd /home/joshua/WebJamApps/CollegeLutheran
git checkout fix-news-signup-console-error
npm ci
npm test                 # unit suite (48 files / 130 tests)
npm run dev              # http://localhost:7777
```
Open DevTools console on the **homepage** — the `Div for inline form … is missing` error should be gone. Go to **/news** — the Constant Contact sign-up form still renders (and in a browser that blocks the script, the "contact the church office (Sandi Roop)…" fallback appears instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)