### PR TITLE
fix(news): render the sign-up form on every visit

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,14 +20,6 @@
 </head>
 
 <body>
-  <!-- Target for Constant Contact inline signup form widget - adding id for better lookup -->
-  <div id="ctct-inline-form" class="ctct-inline-form" data-form-id="Inline Form Created 2022/07/09, 12:42:54 PM">
-    <noscript>
-      <p>To sign up for our newsletter, please <a
-          href="https://visitor.r20.constantcontact.com/manage/optin?v=001cd950f6ed99253e212302d6c939739">click
-          here</a>.</p>
-    </noscript>
-  </div>
   <div id="root">
     <div class="splash">
       <div class="message">College Lutheran Church</div>
@@ -35,13 +27,6 @@
     </div>
   </div>
   <script type="module" src="/src/Main.tsx"></script>
-  <!-- Begin Constant Contact Active Forms - moved to bottom to ensure div is present -->
-  <script>
-    var _ctct_m = "01cd950f6ed99253e212302d6c939739";
-  </script>
-  <script id="signupScript" src="https://static.ctctcdn.com/js/signup-form-widget/current/signup-form-widget.min.js"
-    async defer></script>
-  <!-- End Constant Contact Active Forms -->
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,14 @@
 </head>
 
 <body>
+  <!-- Target for Constant Contact inline signup form widget - adding id for better lookup -->
+  <div id="ctct-inline-form" class="ctct-inline-form" data-form-id="Inline Form Created 2022/07/09, 12:42:54 PM">
+    <noscript>
+      <p>To sign up for our newsletter, please <a
+          href="https://visitor.r20.constantcontact.com/manage/optin?v=001cd950f6ed99253e212302d6c939739">click
+          here</a>.</p>
+    </noscript>
+  </div>
   <div id="root">
     <div class="splash">
       <div class="message">College Lutheran Church</div>
@@ -27,6 +35,13 @@
     </div>
   </div>
   <script type="module" src="/src/Main.tsx"></script>
+  <!-- Begin Constant Contact Active Forms - moved to bottom to ensure div is present -->
+  <script>
+    var _ctct_m = "01cd950f6ed99253e212302d6c939739";
+  </script>
+  <script id="signupScript" src="https://static.ctctcdn.com/js/signup-form-widget/current/signup-form-widget.min.js"
+    async defer></script>
+  <!-- End Constant Contact Active Forms -->
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.20",
+  "version": "2.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.20",
+      "version": "2.1.21",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.20",
+  "version": "2.1.21",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/News/NewsContent.tsx
+++ b/src/containers/News/NewsContent.tsx
@@ -21,6 +21,19 @@ export function SignUpForEmails({ height }: { height: number }) {
   const formRef = useRef<HTMLDivElement>(null);
   const [unavailable, setUnavailable] = useState(false);
   useEffect(() => {
+    // The Constant Contact widget only scans the page once per script execution,
+    // so when you reach /news via an in-app (SPA) navigation the freshly-mounted
+    // div is left empty and no form appears. Re-run the widget on every mount:
+    // clear the div, drop any prior instance, and append a fresh script to force
+    // a re-scan so the form shows up on every visit.
+    (window as unknown as { _ctct_m?: string })._ctct_m = '01cd950f6ed99253e212302d6c939739';
+    if (formRef.current) formRef.current.innerHTML = '';
+    document.getElementById('ctctSignupScript')?.remove();
+    const s = document.createElement('script');
+    s.id = 'ctctSignupScript';
+    s.src = 'https://static.ctctcdn.com/js/signup-form-widget/current/signup-form-widget.min.js';
+    s.async = true;
+    document.body.appendChild(s);
     const timer = setTimeout(() => {
       if (formRef.current && formRef.current.childElementCount === 0) setUnavailable(true);
     }, 3500);

--- a/src/containers/News/NewsContent.tsx
+++ b/src/containers/News/NewsContent.tsx
@@ -4,32 +4,23 @@ import {
 } from 'react';
 import { AuthContext } from 'src/providers/Auth.provider';
 import { checkIsAdmin } from 'src/App';
+import { Button } from '@mui/material';
+import { useElementHeight } from 'src/lib/useWindowSize';
 import ELCALogo from 'src/components/elcaLogo';
 import { EditNewsDialog } from './EditNewsDialog';
 import { defaultNews } from './utilsN';
 
 // The email sign-up is a Constant Contact inline form injected by an external
-// script (see index.html). Firefox's Enhanced Tracking Protection blocks that
-// script, so the div stays empty and no form appears. We can't link a direct
-// sign-up URL (we don't have one), so when the form fails to render we show a
-// fallback asking people to contact the office. Detection: if the CTCT div is
-// still empty a few seconds after mount, the script was blocked/failed.
-export function SignUpForEmails() {
+// script loaded globally in index.html. Firefox's Enhanced Tracking Protection
+// blocks that script, so the div stays empty and no form appears. Two safety
+// nets: (1) a "Sign Up for Emails" button that reloads the page to re-trigger
+// the script — this recovers the form when it didn't render (e.g. on an SPA
+// revisit); and (2) if the div is still empty ~3.5s after mount, a fallback
+// asking people to contact the office (Sandi Roop).
+export function SignUpForEmails({ height }: { height: number }) {
   const formRef = useRef<HTMLDivElement>(null);
   const [unavailable, setUnavailable] = useState(false);
   useEffect(() => {
-    // Load the Constant Contact widget here, on the only page that has its target
-    // div. Loading it globally from index.html made the widget log "Div for inline
-    // form ... is missing" on every other page, none of which has a div for it.
-    (window as unknown as { _ctct_m?: string })._ctct_m = '01cd950f6ed99253e212302d6c939739';
-    if (!document.getElementById('ctctSignupScript')) {
-      const s = document.createElement('script');
-      s.id = 'ctctSignupScript';
-      s.src = 'https://static.ctctcdn.com/js/signup-form-widget/current/signup-form-widget.min.js';
-      s.async = true;
-      s.defer = true;
-      document.body.appendChild(s);
-    }
     const timer = setTimeout(() => {
       if (formRef.current && formRef.current.childElementCount === 0) setUnavailable(true);
     }, 3500);
@@ -37,6 +28,15 @@ export function SignUpForEmails() {
   }, []);
   return (
     <>
+      {height < 700 ? (
+        <Button
+          onClick={() => window.location.reload()}
+          size="large"
+          variant="contained"
+        >
+          Sign Up for Emails
+        </Button>
+      ) : null}
       <div ref={formRef} className="ctct-inline-form" data-form-id="99081bd2-b1a5-48cd-bb60-8c9aba82c2a4" />
       {unavailable ? (
         <div className="signup-unavailable">
@@ -61,6 +61,7 @@ interface NewsContentProps {
   books?: Ibook[];
 }
 export function NewsContent({ books }: NewsContentProps) {
+  const { height, ref } = useElementHeight<HTMLDivElement>();
   const { auth } = useContext(AuthContext);
   const [isAdmin, setIsAdmin] = useState(false);
   const [editNews, setEditNews] = useState(defaultNews);
@@ -118,8 +119,8 @@ export function NewsContent({ books }: NewsContentProps) {
         </div>
         <p style={{ fontSize: '4pt', margin: '0' }}>&nbsp;</p>
         <hr style={{ margin: '0px' }} />
-        <div style={{ margin: 'auto', textAlign: 'center' }}>
-          <SignUpForEmails />
+        <div ref={ref} style={{ margin: 'auto', textAlign: 'center' }}>
+          <SignUpForEmails height={height || 100} />
         </div>
       </div>
       <EditNewsDialog editNews={editNews} setEditNews={setEditNews} />

--- a/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
+++ b/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
@@ -22,6 +22,11 @@ exports[`NewsContent > renders the news page 1`] = `
       <div
         style="margin: auto; text-align: center;"
       >
+        <button
+          variant="contained"
+        >
+          Sign Up for Emails
+        </button>
         <div
           class="ctct-inline-form"
           data-form-id="99081bd2-b1a5-48cd-bb60-8c9aba82c2a4"

--- a/test/e2e/news-signup.spec.ts
+++ b/test/e2e/news-signup.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
 
 // Guards the News-page email sign-up fallback. The sign-up is a Constant Contact
-// inline form injected by an external script (signup-form-widget.min.js). Firefox
-// Enhanced Tracking Protection blocks that script, leaving the form empty — what
-// Pastor David reported. We simulate the block by aborting the script request,
-// which is deterministic across browsers, then assert the contact-the-office
-// fallback appears and the old floating "Sign Up for Emails" reload button is
-// gone. Runs on desktop + mobile (see playwright.config.ts projects).
+// inline form injected by an external script (signup-form-widget.min.js) loaded
+// in index.html. Firefox Enhanced Tracking Protection blocks that script, leaving
+// the form empty — what Pastor David reported. We simulate the block by aborting
+// the script request, which is deterministic across browsers, then assert the
+// contact-the-office fallback appears. Runs on desktop + mobile (see
+// playwright.config.ts projects).
 
 test('shows the contact-the-office fallback when the sign-up form is blocked', async ({ page }) => {
   await page.route('**/signup-form-widget*', (route) => route.abort());
@@ -21,9 +21,6 @@ test('shows the contact-the-office fallback when the sign-up form is blocked', a
   await expect(fallback).toContainText('Sandi Roop');
   await expect(fallback.getByRole('link', { name: 'office1@collegelutheran.org' })).toBeVisible();
   await expect(fallback.getByRole('link', { name: '(540) 389-4963' })).toBeVisible();
-
-  // The old reload button that floated over the News table must be gone.
-  await expect(page.getByRole('button', { name: 'Sign Up for Emails' })).toHaveCount(0);
 });
 
 test('does not show the fallback when the form renders', async ({ page }) => {


### PR DESCRIPTION
## What

Make the Constant Contact sign-up form appear **every time** you open `/news` — including via the in-app menu and on revisits — instead of only on a fresh/direct page load.

The widget only scans the page once per script execution, so an SPA route change left the freshly-mounted div empty. Fix: load the widget from the News component and **re-run it on every mount** (clear the div, drop any prior script instance, append a fresh one to force a re-scan).

Keeping the script in `index.html` actually **broke the first visit** (the global instance conflicts with the per-mount re-run), so it's removed from `index.html`. That also clears the homepage `Div for inline form … is missing` console error.

Kept as backups, per request:
- the `height < 700` **"Sign Up for Emails"** reload button, and
- the **Sandi Roop** contact fallback (shown if the script is blocked, e.g. Firefox ETP).

## Verified (headless browser)
| Path | Form renders |
|---|---|
| menu nav: home → News | ✅ |
| revisit: News → home → News | ✅ |
| homepage CTCT console error | gone |

## How to Test Locally
```bash
cd /home/joshua/WebJamApps/CollegeLutheran
git checkout fix-news-signup-console-error && npm ci
npm test
npm run dev   # http://localhost:7777
```
Click **News** from the menu → the form appears. Navigate away and back → it appears again. If the script is blocked, the contact-the-office fallback shows; the reload button is there as a manual recovery.

version 2.1.20 → 2.1.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)