### PR TITLE
feat(news): loading spinners for Add News and Edit News submit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,7 @@ than adding a UI library — e.g. a loading spinner is `<CircularProgress />` fr
 - Do not edit CI config or anything under `.github/` unless the task is about it.
 - e2e tests (`npm run test:e2e`, Playwright) need a browser install and a running
   app; you don't need to run them — unit tests + lint are the gate.
+
+## Memory
+- **News Flow:** Creating "News" is handled via the `ChangeNewsPage` component in `src/containers/AdminDashboard/AdminDashboardContent.tsx`. Updating and Deleting news happens through `src/containers/News/EditNewsDialog.tsx`.
+- **Async Testing:** When components have `await` calls that disable buttons (like during API calls), tests using `@testing-library/react` need to mock functions to return Promises (`vi.fn(() => Promise.resolve())`) and interactions should be wrapped in `await act(async () => { ... })` to properly flush React state.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.21",
+  "version": "2.1.22",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/src/containers/AdminDashboard/AdminDashboardContent.tsx
+++ b/src/containers/AdminDashboard/AdminDashboardContent.tsx
@@ -1,5 +1,5 @@
 import {
-  Button, TextField, Checkbox, FormControlLabel, FormGroup, Stack,
+  Button, TextField, Checkbox, FormControlLabel, FormGroup, Stack, CircularProgress,
 } from '@mui/material';
 import {
   SetStateAction, useContext, useState,
@@ -64,10 +64,21 @@ export function ChangeNewsPage() {
   const [title, setTitle] = useState('');
   const [url, setUrl] = useState('');
   const [comments, setComments] = useState('');
+  const [loading, setLoading] = useState(false);
   const clearForm = () => {
     setTitle(''); setUrl(''); setComments('');
   };
   const handleChange = makeHandleChange(setComments);
+
+  const handleAddNews = async () => {
+    setLoading(true);
+    try {
+      await utils.addNewsAPI(auth, getNews, clearForm, { title, url, comments });
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="material-content elevation3" style={{ maxWidth: '8in', margin: '30px auto auto auto' }}>
       <h5>Add to News Page</h5>
@@ -90,11 +101,10 @@ export function ChangeNewsPage() {
       <Button
         size="small"
         variant="contained"
-        onClick={() => utils.addNewsAPI(
-          auth, getNews, clearForm, { title, url, comments },
-        )}
+        disabled={loading}
+        onClick={handleAddNews}
       >
-        Add News
+        {loading ? <CircularProgress size={20} color="inherit" className="addNewsSpinner" /> : 'Add News'}
       </Button>
     </div>
   );

--- a/src/containers/News/EditNewsDialog.tsx
+++ b/src/containers/News/EditNewsDialog.tsx
@@ -1,9 +1,10 @@
 import {
   Button,
   Checkbox,
+  CircularProgress,
   Dialog, DialogActions, DialogContent, DialogTitle, FormControlLabel, FormGroup, TextField,
 } from '@mui/material';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { AuthContext } from 'src/providers/Auth.provider';
 import { ContentContext } from 'src/providers/Content.provider';
 import libUtils from 'src/lib/commonUtils';
@@ -88,28 +89,35 @@ export function EditNewsButtons(props: IeditNewsDialogProps) {
   const { editNews, setEditNews } = props;
   const { auth } = useContext(AuthContext);
   const { getNews } = useContext(ContentContext);
+  const [loading, setLoading] = useState(false);
+  const handleNewsAction = async (method: string) => {
+    setLoading(true);
+    try { await utils.newsApi(method, { editNews, setEditNews }, auth, getNews); } finally { setLoading(false); }
+  };
   return (
     <DialogActions>
       <>
         <Button
-          disabled={!checkDisabled(editNews)}
+          disabled={!checkDisabled(editNews) || loading}
           size="small"
           variant="contained"
           className="updateNewsButton"
-          onClick={() => (async () => { await utils.newsApi('put', { editNews, setEditNews }, auth, getNews); })()}
+          onClick={() => { handleNewsAction('put'); }}
         >
-          Update
+          {loading ? <CircularProgress size={20} color="inherit" className="newsSubmitSpinner" /> : 'Update'}
         </Button>
         <Button
           style={{ backgroundColor: 'red', color: 'white' }}
+          disabled={loading}
           size="small"
           className="deleteNewsButton"
-          onClick={() => (async () => { await utils.newsApi('delete', { editNews, setEditNews }, auth, getNews); })()}
+          onClick={() => { handleNewsAction('delete'); }}
         >
-          Delete
+          {loading ? <CircularProgress size={20} color="inherit" className="newsSubmitSpinner" /> : 'Delete'}
         </Button>
         <Button
           size="small"
+          disabled={loading}
           className="cancelNewsButton"
           onClick={() => setEditNews(defaultNews)}
         >

--- a/test/containers/AdminDashboard/AdminDashboardContent.spec.tsx
+++ b/test/containers/AdminDashboard/AdminDashboardContent.spec.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import {
   ButtonsNav,
   ChangeHomePageSect, ChangeNewsPage, ChangeYouthPageSect, makeHandleChange,
@@ -61,13 +62,26 @@ describe('AdminDashboard Content', () => {
     handleChange(evt);
     expect(setComments).toHaveBeenCalledWith('');
   });
-  it('handles onClick for addNewsAPI button', () => {
-    utils.addNewsAPI = vi.fn();
+  it('handles onClick for addNewsAPI button', async () => {
+    utils.addNewsAPI = vi.fn(() => Promise.resolve());
     const { container } = render(<ChangeNewsPage />);
     const btn = container.querySelector('button[variant="contained"]') as HTMLButtonElement | null;
     expect(btn).not.toBeNull();
-    fireEvent.click(btn!);
+    await act(async () => { fireEvent.click(btn!); });
     expect(utils.addNewsAPI).toHaveBeenCalled();
+  });
+  it('shows a spinner while news is being added', async () => {
+    let resolveApi!: () => void;
+    utils.addNewsAPI = vi.fn(() => new Promise<void>((resolve) => { resolveApi = resolve; }));
+    const { container } = render(<ChangeNewsPage />);
+    const btn = container.querySelector('button[variant="contained"]') as HTMLButtonElement;
+    expect(container.querySelector('.addNewsSpinner')).toBeNull();
+    await act(async () => { fireEvent.click(btn); });
+    expect(container.querySelector('.addNewsSpinner')).not.toBeNull();
+    await act(async () => { resolveApi(); });
+    await waitFor(() => {
+      expect(container.querySelector('.addNewsSpinner')).toBeNull();
+    });
   });
   it('handles onChange for ChangeYouthPage', () => {
     const { container } = render(<ChangeYouthPageSect />);

--- a/test/containers/News/EditNewsDialog.spec.tsx
+++ b/test/containers/News/EditNewsDialog.spec.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import {
   EditNewsDialog, NewsTextField, EditNewsContent, EditNewsButtons,
 } from 'src/containers/News/EditNewsDialog';
@@ -36,8 +37,8 @@ describe('EditNewsDialog', () => {
     fireEvent.change(titleInput!, { target: { value: 'title' } });
     expect(setEditNews).toHaveBeenCalledTimes(2);
   });
-  it('renders EditNewsButtons and handles events', () => {
-    utils.newsApi = vi.fn();
+  it('renders EditNewsButtons and handles events', async () => {
+    utils.newsApi = vi.fn(() => Promise.resolve());
     const props = {
       editNews: { ...defaultNews, title: 't', url: 'u' },
       setEditNews: vi.fn(),
@@ -46,11 +47,28 @@ describe('EditNewsDialog', () => {
     const update = container.querySelector('.updateNewsButton') as HTMLButtonElement | null;
     const del = container.querySelector('.deleteNewsButton') as HTMLButtonElement | null;
     const cancel = container.querySelector('.cancelNewsButton') as HTMLButtonElement | null;
-    fireEvent.click(update!);
+    await act(async () => { fireEvent.click(update!); });
     expect(utils.newsApi).toHaveBeenCalled();
-    fireEvent.click(del!);
+    await act(async () => { fireEvent.click(del!); });
     expect(utils.newsApi).toHaveBeenCalledTimes(2);
     fireEvent.click(cancel!);
     expect(props.setEditNews).toHaveBeenCalled();
+  });
+  it('shows a spinner while news is being submitted', async () => {
+    let resolveApi!: () => void;
+    utils.newsApi = vi.fn(() => new Promise<void>((resolve) => { resolveApi = resolve; }));
+    const props = {
+      editNews: { ...defaultNews, title: 't', url: 'u' },
+      setEditNews: vi.fn(),
+    };
+    const { container } = render(<EditNewsButtons {...props} />);
+    expect(container.querySelector('.newsSubmitSpinner')).toBeNull();
+    const update = container.querySelector('.updateNewsButton') as HTMLButtonElement;
+    await act(async () => { fireEvent.click(update); });
+    expect(container.querySelector('.newsSubmitSpinner')).not.toBeNull();
+    await act(async () => { resolveApi(); });
+    await waitFor(() => {
+      expect(container.querySelector('.newsSubmitSpinner')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary
Consolidates three overlapping `gemini/*` spinner branches into a single feature branch off `dev`.

Adds a loading spinner (`CircularProgress`) to news submission actions so the user gets feedback while the request is in flight:
- **Add News** button (`AdminDashboardContent.tsx`) — `addNewsSpinner`
- **Update / Delete** in the Edit News dialog (`EditNewsDialog.tsx`) — `newsSubmitSpinner`; buttons disable while loading

## Reconciliation notes
- `gemini/add-a-spinner-when-i-submit-the-news` — already merged to `dev`, nothing unique; can be deleted.
- `gemini/add-a-loading-spinner-to-the-add-news-bu` — Add News spinner + AGENTS.md note (base of this branch).
- `gemini/add-a-spinner-when-i-submit-the-news-2` — Edit dialog spinner + tests; **code/tests ported here**, its stale `AGENTS.md → GEMINI.md` revert was intentionally dropped.

## Tests
- `npm run test:unit` → 132 passed (48 files), incl. new spinner tests for both components
- `npm run test:lint` → clean
- Manually verified locally (vite :7777 + local web-jam-back); spinner only visible under network throttling because the local backend responds in ~ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)