### PR TITLE
feat(facebook): "Feed updated" timestamp + check-both-pages warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ server over https with a self-signed cert:
      Authorized JavaScript origins **and** Authorized redirect URIs, or Google
      login returns a 400 (the token-exchange `redirect_uri` must match the
      scheme the auth code was issued under).
+
+> **When you log into Facebook to Reconnect, keep BOTH the CollegeLutheran and WebJamLLC
+> pages checked.** web-jam-back now serves both pages from the one "Web Jam LLC" Meta app
+> (web-jam-back#799), and the Facebook consent dialog's page selection is a *replace*, not
+> an add: unchecking a page you previously granted revokes the app's access to it and kills
+> that page's stored token. So even though this admin only reconnects CollegeLutheran, leave
+> WebJamLLC checked too (and vice-versa from the JaMmusic side).

--- a/src/containers/Homepage/FacebookPosts.tsx
+++ b/src/containers/Homepage/FacebookPosts.tsx
@@ -22,6 +22,7 @@ export interface FacebookPostsProps { maxWidth?: number; maxHeight?: number; tes
 
 export const FacebookPosts = ({ maxWidth = 500, maxHeight = 485, testId }: FacebookPostsProps) => {
   const [posts, setPosts] = useState<FbPost[]>([]);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   useEffect(() => {
     let active = true;
     const load = async () => {
@@ -29,7 +30,7 @@ export const FacebookPosts = ({ maxWidth = 500, maxHeight = 485, testId }: Faceb
         const res = await fetch(`${process.env.BackendUrl}/facebook/feed`);
         const data = await res.json() as FeedResponse;
         const fresh = !!data.lastUpdated && Date.now() - new Date(data.lastUpdated).getTime() < STALE_MS;
-        if (active && fresh && Array.isArray(data.posts)) setPosts(data.posts);
+        if (active && fresh && Array.isArray(data.posts)) { setPosts(data.posts); setLastUpdated(data.lastUpdated); }
       } catch { /* leave posts empty → the page-link fallback renders below */ }
     };
     void load();
@@ -41,42 +42,49 @@ export const FacebookPosts = ({ maxWidth = 500, maxHeight = 485, testId }: Faceb
   // fallback link here would just duplicate it.
   if (posts.length === 0) return null;
   return (
-    <div
-      className="fbFeed"
-      data-testid={testId}
-      style={{
-        maxWidth: `${maxWidth}px`, margin: 'auto', maxHeight: `${maxHeight}px`, overflowY: 'auto', textAlign: 'left',
-      }}
-    >
-      {posts.map((post) => (
-        <a
-          key={post.id || post.permalink_url}
-          className="fbPost"
-          href={post.permalink_url || PAGE_URL}
-          target="_blank"
-          rel="noreferrer"
-          style={{
-            display: 'block',
-            textDecoration: 'none',
-            color: 'inherit',
-            border: '1px solid #ddd',
-            borderRadius: '6px',
-            padding: '8px',
-            marginBottom: '10px',
-          }}
-        >
-          {post.full_picture ? (
-            <img src={post.full_picture} alt="" style={{ width: '100%', borderRadius: '4px', marginBottom: '6px' }} />
-          ) : null}
-          {post.message ? <p style={{ fontSize: '10pt', margin: '0 0 4px' }}>{post.message}</p> : null}
-          {post.created_time ? (
-            <span style={{ fontSize: '8pt', color: '#666' }}>
-              {new Date(post.created_time).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
-            </span>
-          ) : null}
-        </a>
-      ))}
-    </div>
+    <>
+      <div
+        className="fbFeed"
+        data-testid={testId}
+        style={{
+          maxWidth: `${maxWidth}px`, margin: 'auto', maxHeight: `${maxHeight}px`, overflowY: 'auto', textAlign: 'left',
+        }}
+      >
+        {posts.map((post) => (
+          <a
+            key={post.id || post.permalink_url}
+            className="fbPost"
+            href={post.permalink_url || PAGE_URL}
+            target="_blank"
+            rel="noreferrer"
+            style={{
+              display: 'block',
+              textDecoration: 'none',
+              color: 'inherit',
+              border: '1px solid #ddd',
+              borderRadius: '6px',
+              padding: '8px',
+              marginBottom: '10px',
+            }}
+          >
+            {post.full_picture ? (
+              <img src={post.full_picture} alt="" style={{ width: '100%', borderRadius: '4px', marginBottom: '6px' }} />
+            ) : null}
+            {post.message ? <p style={{ fontSize: '10pt', margin: '0 0 4px' }}>{post.message}</p> : null}
+            {post.created_time ? (
+              <span style={{ fontSize: '8pt', color: '#666' }}>
+                {new Date(post.created_time).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+              </span>
+            ) : null}
+          </a>
+        ))}
+      </div>
+      {lastUpdated ? (
+        <p className="fbUpdated" style={{ fontSize: '8pt', color: '#666', textAlign: 'center', margin: '4px 0 0' }}>
+          {`Feed updated ${new Date(lastUpdated).toLocaleString()}`}
+        </p>
+      ) : null}
+    </>
   );
 };
 

--- a/test/containers/Homepage/FacebookPosts.spec.tsx
+++ b/test/containers/Homepage/FacebookPosts.spec.tsx
@@ -27,6 +27,7 @@ describe('FacebookPosts', () => {
     const first = container.querySelector('.fbPost') as HTMLAnchorElement;
     expect(first.getAttribute('href')).toBe('https://fb/p1');
     expect(container.querySelector('img')?.getAttribute('src')).toBe('https://img/1.jpg');
+    expect(container.querySelector('.fbUpdated')?.textContent).toMatch(/^Feed updated /);
   });
 
   it('renders nothing when the feed is empty (the header above is the fallback link)', async () => {


### PR DESCRIPTION
## What

- Renders a **"Feed updated &lt;time&gt;"** line beneath the homepage Facebook cards, from the backend's `lastUpdated` (the last successful hourly refresh). Matches the same addition in JaMmusic.
- README: a note to keep **both** the CollegeLutheran and WebJamLLC pages checked in the Facebook consent dialog when reconnecting — web-jam-back#799 now serves both pages from the one "Web Jam LLC" Meta app, and the dialog's page selection is a *replace*, so deselecting a page revokes its token.

Only the cards path changes; the timestamp renders only when a fresh feed is present (nothing when empty/stale), so the Wide/Narrow feed snapshots are unaffected.

## Verification

- `eslint` clean · prod `tsc --noEmit` clean · 14 Homepage tests pass (FacebookPosts spec asserts the timestamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)