### PR TITLE
fix(facebook): force page picker on reconnect + surface backend error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
             # listens, reads MONGO_DB_URI (the test DB), and skips the reseed.
             NODE_ENV=production MONGO_DB_URI="$MONGO_DB_URI" \
               AllowUrl='{"urls":["http://localhost:7777"]}' \
+              FB_PAGE_ID=202368653220334 \
+              FB_PAGES='{"202368653220334":"CollegeLutheran","365007513885497":"WebJamLLC"}' \
+              FB_APP_ID=2207148322688942 \
               PORT=7000 node /tmp/wjb/build/src/index.js > /tmp/wjb.log 2>&1 &
             for _ in $(seq 1 30); do curl -sf "http://localhost:7000/book?type=Forum" >/dev/null && break; sleep 2; done
             cat /tmp/wjb.log || true

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ server over https with a self-signed cert:
      Authorized JavaScript origins **and** Authorized redirect URIs, or Google
      login returns a 400 (the token-exchange `redirect_uri` must match the
      scheme the auth code was issued under).
+   - **Meta app (Facebook)** — add `localhost` to **Allowed Domains for the
+     JavaScript SDK** (and **App Domains**) in the Web Jam LLC app, or `FB.login`
+     fails with *"JSSDK Unknown Host domain"*. The full domain list for every
+     environment (including the production `web-jam.com` host) is in
+     **web-jam-back's README**.
 
 > **When you log into Facebook to Reconnect, keep BOTH the CollegeLutheran and WebJamLLC
 > pages checked.** web-jam-back now serves both pages from the one "Web Jam LLC" Meta app

--- a/src/containers/AdminDashboard/utils.tsx
+++ b/src/containers/AdminDashboard/utils.tsx
@@ -125,7 +125,7 @@ export const FB_GRAPH_VERSION = 'v20.0';
 interface FbLoginResponse { authResponse?: { accessToken?: string } }
 interface FbSdk {
   init: (opts: Record<string, unknown>) => void;
-  login: (cb: (res: FbLoginResponse) => void, opts: { scope: string }) => void;
+  login: (cb: (res: FbLoginResponse) => void, opts: { scope: string; auth_type?: string }) => void;
 }
 interface FbWindow extends Window { FB?: FbSdk; fbAsyncInit?: () => void }
 
@@ -154,7 +154,7 @@ function loadFbSdk(): void {
 // not function").
 async function sendPageToken(userToken: string, auth: Iauth): Promise<void> {
   try {
-    await jsonRequest(`${process.env.BackendUrl}/facebook/token`, {
+    const res = await fetch(`${process.env.BackendUrl}/facebook/token`, {
       method: 'PUT',
       headers: {
         Authorization: `Bearer ${auth.token}`,
@@ -163,6 +163,10 @@ async function sendPageToken(userToken: string, auth: Iauth): Promise<void> {
       },
       body: JSON.stringify({ userToken }),
     });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({})) as { message?: string };
+      throw new Error(body.message || `HTTP ${res.status}`);
+    }
     commonUtils.notify('Facebook', 'Reconnected — the feed will refresh shortly', 'success');
   } catch (e) {
     commonUtils.notify('Facebook', `Reconnect failed, ${(e as Error).message}`, 'warning');
@@ -170,7 +174,10 @@ async function sendPageToken(userToken: string, auth: Iauth): Promise<void> {
 }
 
 // "Reconnect Facebook": admin logs in as the page admin → short-lived user
-// token → sendPageToken to web-jam-back.
+// token → sendPageToken to web-jam-back. `auth_type: 'rerequest'` forces the
+// page picker every time rather than silently reusing the last grant, so a
+// prior reconnect of a different page can't leave this one ungranted. Keep BOTH
+// the CollegeLutheran and WebJamLLC pages checked — deselecting one revokes it.
 async function reconnectFacebookAPI(auth: Iauth): Promise<void> {
   const w = window as unknown as FbWindow;
   if (!w.FB) {
@@ -186,7 +193,7 @@ async function reconnectFacebookAPI(auth: Iauth): Promise<void> {
         return;
       }
       void sendPageToken(userToken, auth).finally(resolve);
-    }, { scope: 'pages_show_list,pages_read_engagement' });
+    }, { scope: 'pages_show_list,pages_read_engagement', auth_type: 'rerequest' });
   });
 }
 

--- a/test/containers/AdminDashboard/utils.spec.tsx
+++ b/test/containers/AdminDashboard/utils.spec.tsx
@@ -170,15 +170,17 @@ describe('Admin Dash utils', () => {
       expect(commonUtils.notify).toHaveBeenCalledWith('Facebook', expect.stringMatching(/still loading/), 'warning');
     });
 
-    it('PUTs the user token and notifies success', async () => {
+    it('PUTs the user token (rerequesting the page picker) and notifies success', async () => {
       commonUtils.notify = vi.fn();
-      (window as any).FB = {
-        init: vi.fn(),
-        login: (cb: (r: any) => void) => cb({ authResponse: { accessToken: 'USER-TOKEN' } }),
-      };
+      const loginMock = vi.fn((cb: (r: any) => void) => cb({ authResponse: { accessToken: 'USER-TOKEN' } }));
+      (window as any).FB = { init: vi.fn(), login: loginMock };
       const fetchMock = vi.fn(() => Promise.resolve({ ok: true, status: 200 }));
       vi.stubGlobal('fetch', fetchMock);
       await utils.reconnectFacebookAPI(auth as any);
+      expect(loginMock).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ auth_type: 'rerequest' }),
+      );
       expect(fetchMock).toHaveBeenCalledWith(
         `${process.env.BackendUrl}/facebook/token`,
         {
@@ -197,15 +199,19 @@ describe('Admin Dash utils', () => {
       expect(commonUtils.notify).toHaveBeenCalledWith('Facebook', expect.stringMatching(/cancelled/), 'warning');
     });
 
-    it('warns when the backend PUT fails', async () => {
+    it('surfaces the backend error message when the PUT fails', async () => {
       commonUtils.notify = vi.fn();
       (window as any).FB = {
         init: vi.fn(),
         login: (cb: (r: any) => void) => cb({ authResponse: { accessToken: 'USER-TOKEN' } }),
       };
-      vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, status: 400 })));
+      vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+        ok: false, status: 400, json: () => Promise.resolve({ message: 'CollegeLutheran page not found in /me/accounts' }),
+      })));
       await utils.reconnectFacebookAPI(auth as any);
-      expect(commonUtils.notify).toHaveBeenCalledWith('Facebook', expect.stringMatching(/Reconnect failed/), 'warning');
+      expect(commonUtils.notify).toHaveBeenCalledWith(
+        'Facebook', expect.stringMatching(/Reconnect failed.*page not found/), 'warning',
+      );
     });
   });
 });


### PR DESCRIPTION
## Why

Mirrors the JaMmusic fix (WebJamApps/JaMmusic#1110). The reconnect `FB.login` reused the previous grant ("continue with previous settings"), so reconnecting one page could leave the other ungranted and the token exchange would 400 with `page not found in /me/accounts`.

## Changes

- **`auth_type: 'rerequest'`** on `FB.login` — forces the page picker every reconnect.
- **Surface the backend error** — `sendPageToken` now reads the response body's `message` (inline `fetch` instead of `jsonRequest`), so the toast says *why* instead of a bare `HTTP 400`.
- **README** — documents the **Allowed Domains for the JavaScript SDK** Meta-app setup, pointing to web-jam-back for the full per-environment domain list.

## Verification
- eslint + prod `tsc` clean; AdminDashboard `utils` specs pass (assert `rerequest` is sent and the backend message is surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)