### PR TITLE
docs: AGENTS.md self-references updated from GEMINI.md (memory-cleanup)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
-# GEMINI.md — CollegeLutheran
+# AGENTS.md — CollegeLutheran
 
-Guidance for gemini-cli when working in this repo. (Global rules live in
-`~/.gemini/GEMINI.md`; this file adds CollegeLutheran specifics.)
+Guidance for AI coding agents (agy/Antigravity, etc.) working in this repo.
+(Global rules live in `~/.agents/AGENTS.md`; this file adds CollegeLutheran
+specifics.)
 
 ## What this is
 A React + TypeScript + Vite front-end for College Lutheran Church. State via

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.23",
+  "version": "2.1.24",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {


### PR DESCRIPTION
## Summary
The 2026-06-13 /memory-cleanup run flagged that AGENTS.md (renamed from GEMINI.md in June 2026) still titled itself `GEMINI.md — CollegeLutheran` and pointed to the retired `~/.gemini/GEMINI.md` global path. Updated to agent-neutral wording pointing at `~/.agents/AGENTS.md` (verified to exist). Version bumped 2.1.23 → 2.1.24.

## How to Test Locally
1. `git checkout docs-agents-md-rename`
2. `cat AGENTS.md | head -8` — header reads `# AGENTS.md — CollegeLutheran` and references `~/.agents/AGENTS.md`.
3. Docs-only change; no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)