### PR TITLE
security(hygiene): drop dead HashString config so the JWT secret can't be bundled (#756)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ BackendUrl=http://localhost:7000
 GoogleClientId=
 userRoles={"roles": ["Rolename1", "Rolename2"]}
 AllowUrl={"urls": ["http://something.com", "https://something.com", "http://localhost:7000", "http://localhost:9000"]}
-HashString=
 TINY_KEY=
 CHANNEL_ID=
 FB_PAGE_ID=202368653220334

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.24",
+  "version": "2.1.25",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,6 @@ function devHttps(env: Record<string, string>) {
 const APP_ENV_KEYS = [
   'BackendUrl',
   'GoogleClientId',
-  'HashString',
   'TINY_KEY',
   'CHANNEL_ID',
   'userRoles',


### PR DESCRIPTION
Closes #756.

## Context
Found while fixing the JWT-secret-in-bundle leak in JaMmusic (JaMmusic#1124, PR #1125).

**CollegeLutheran is not currently vulnerable** — it decodes tokens with `jwt-decode` (`jwtDecode(token)`, no secret), and nothing references `process.env.HashString`, so the secret never enters the bundle.

## Change (config-only)
Remove the latent footgun so the secret can never be bundled, even by accident later:
- `vite.config.ts` — drop `'HashString'` from `APP_ENV_KEYS`.
- `.env.example` — drop the `HashString=` line.

## Verification
- `grep -rn 'process.env.HashString' src/` → none.
- `npm test` (lint + 144 unit tests) green. Version → 2.1.25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)