### PR TITLE
Add dark mode selector

### DIFF
--- a/__mocks__/@mui/material.tsx
+++ b/__mocks__/@mui/material.tsx
@@ -88,6 +88,14 @@ export function CircularProgress(props: any) {
   return <div {...props} />;
 }
 
+export function CssBaseline() {
+  return null;
+}
+
+export function GlobalStyles() {
+  return null;
+}
+
 export function Box(props: any) {
   const { children } = props;
   return <div {...props}>{children}</div>;

--- a/src/App/AppTemplate/DrawerContainer.tsx
+++ b/src/App/AppTemplate/DrawerContainer.tsx
@@ -1,5 +1,6 @@
 import { NavLinks } from './NavLinks';
 import './index.scss';
+import { useTheme } from '@mui/material/styles';
 
 interface IdrawerContainerProps {
   handleKeyPress: (arg0:any)=>void, className:any, userCount?:number,
@@ -9,9 +10,10 @@ export function DrawerContainer(props:IdrawerContainerProps) {
   const {
     className, handleClose, handleKeyPress,
   } = props;
+  const theme = useTheme();
   return (
     <div tabIndex={0} role="button" id="sidebar" onClick={handleClose} onKeyPress={handleKeyPress} className={className}>
-      <div className="drawer" style={{ backgroundColor: '#c0c0c0', zIndex: -1, position: 'relative' }}>
+      <div className="drawer" style={{ backgroundColor: theme.palette.background.paper, zIndex: -1, position: 'relative' }}>
         <div className="navImage">
           <img
             alt="Luther Rose"

--- a/src/App/AppTemplate/Footer.tsx
+++ b/src/App/AppTemplate/Footer.tsx
@@ -1,4 +1,6 @@
 
+import { useTheme } from '@mui/material/styles';
+
 const footerLinks = () => {
   const links = [
     { href: 'https://www.facebook.com/CollegeLutheranChurch/', name: 'facebook', label: 'Facebook' },
@@ -30,14 +32,21 @@ const footerLinks = () => {
   );
 };
 
-export const Footer = () => (
-  <div
-    id="wjfooter"
-    className="footer"
-    style={{
-      marginTop: '20px', paddingTop: '20px', paddingBottom: '20px', bottom: '0',
-    }}
-  >
-    {footerLinks()}
-  </div>
-);
+export const Footer = () => {
+  const theme = useTheme();
+  return (
+    <div
+      id="wjfooter"
+      className="footer"
+      style={{
+        marginTop: '20px',
+        paddingTop: '20px',
+        paddingBottom: '20px',
+        bottom: '0',
+        backgroundColor: theme.palette.primary.main,
+      }}
+    >
+      {footerLinks()}
+    </div>
+  );
+};

--- a/src/App/AppTemplate/HeaderSection.tsx
+++ b/src/App/AppTemplate/HeaderSection.tsx
@@ -1,9 +1,12 @@
 import { useWindowWidth } from 'src/lib/useWindowSize';
+import { useTheme } from '@mui/material/styles';
+import { ThemeModeSelector } from './ThemeModeSelector';
 
 export function HeaderSection() {
   const width = useWindowWidth();
+  const theme = useTheme();
   return (
-    <div id="header" className="material-header home-header" style={{ backgroundColor: '#244a8bff' }}>
+    <div id="header" className="material-header home-header" style={{ backgroundColor: theme.palette.primary.main }}>
       <div
         className="flex-header"
         style={{
@@ -35,13 +38,14 @@ export function HeaderSection() {
           style={{
             display: width && width < 260 ? 'none' : 'inline',
             maxWidth: '100%',
-            color: '#f4c00eff',
+            color: theme.palette.secondary.main,
             fontSize: width && width > 450 ? '14px' : '9pt',
           }}
         >
           We celebrate God&apos;s grace and share His love in Christ!
         </p>
       </div>
+      <ThemeModeSelector />
     </div>
   );
 }

--- a/src/App/AppTemplate/NavLinks.tsx
+++ b/src/App/AppTemplate/NavLinks.tsx
@@ -1,5 +1,6 @@
 import { menuItems } from './menuConfig';
 import { SideMenuItem } from './SideMenuItem';
+import { useTheme } from '@mui/material/styles';
 
 declare const __APP_VERSION__: string;
 
@@ -10,27 +11,40 @@ export function NavLinks(props: InavLinksProps) {
   const {
     handleClose,
   } = props;
+  const theme = useTheme();
+  const contactPanelStyle = {
+    backgroundColor: theme.palette.primary.main,
+    marginLeft: '0px',
+  };
+  const contactTextStyle = {
+    color: theme.palette.primary.contrastText,
+    marginBottom: '2px',
+    fontSize: '11pt',
+  };
+  const contactLinkStyle = {
+    color: theme.palette.mode === 'dark' ? theme.palette.secondary.light : '#88c1ff',
+  };
   return (
     <div className="nav-list" style={{ width: '220px' }}>
       <p style={{ fontSize: '1px', marginBottom: '2px' }} />
-      <div className="menu-item" style={{ backgroundColor: '#244a8bff' }}>
-        <p style={{ color: '#fff', marginBottom: '2px', fontSize: '11pt' }}>
-          <a href="http://bit.ly/CollegeLutheranDirections" className="menu-hover" style={{ color: '#88c1ff' }}>
+      <div className="menu-item" style={contactPanelStyle}>
+        <p style={contactTextStyle}>
+          <a href="http://bit.ly/CollegeLutheranDirections" className="menu-hover" style={contactLinkStyle}>
             <span>210 S. College Ave</span>
           </a>
           <br />
           Salem, VA 24153
         </p>
       </div>
-      <div className="menu-item" style={{ backgroundColor: '#244a8bff', marginLeft: '0px' }}>
-        <p style={{ color: '#fff', marginBottom: '2px', fontSize: '11pt' }}>
+      <div className="menu-item" style={contactPanelStyle}>
+        <p style={contactTextStyle}>
           <span>ph: </span>
-          <a href="tel:5403894963" className="menu-hover" style={{ color: '#88c1ff' }}>(540) 389-4963</a>
+          <a href="tel:5403894963" className="menu-hover" style={contactLinkStyle}>(540) 389-4963</a>
           <br />
           <span>fax: </span>
           (540) 389-4980
           <br />
-          <a style={{ color: '#88c1ff', wordWrap: 'break-word' }} href="mailto:office1@collegelutheran.org">
+          <a style={{ ...contactLinkStyle, wordWrap: 'break-word' }} href="mailto:office1@collegelutheran.org">
             <span className="menu-hover">office1@collegelutheran.org</span>
           </a>
         </p>

--- a/src/App/AppTemplate/ThemeModeSelector.tsx
+++ b/src/App/AppTemplate/ThemeModeSelector.tsx
@@ -1,0 +1,60 @@
+import { Button, Tooltip } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { ThemePreference, useThemePreference } from '../theme';
+
+const options: { value: ThemePreference, label: string, title: string }[] = [
+  { value: 'light', label: 'Light', title: 'Use light theme' },
+  { value: 'system', label: 'System', title: 'Follow system theme' },
+  { value: 'dark', label: 'Dark', title: 'Use dark theme' },
+];
+
+export function ThemeModeSelector() {
+  const theme = useTheme();
+  const { preference, setPreference } = useThemePreference();
+  return (
+    <div
+      className="theme-mode-selector"
+      aria-label="Theme preference"
+      role="group"
+      style={{
+        border: `1px solid ${theme.palette.divider}`,
+        backgroundColor: theme.palette.mode === 'dark' ? 'rgba(13, 26, 51, 0.72)' : 'rgba(255, 255, 255, 0.16)',
+      }}
+    >
+      {options.map((option) => {
+        const selected = preference === option.value;
+        return (
+          <Tooltip key={option.value} title={option.title}>
+            <Button
+              size="small"
+              type="button"
+              aria-pressed={selected}
+              onClick={() => setPreference(option.value)}
+              className={selected ? 'theme-mode-option selected' : 'theme-mode-option'}
+              sx={{
+                minWidth: { xs: 28, sm: 54 },
+                px: { xs: 0.75, sm: 1 },
+                py: 0.25,
+                borderRadius: 0,
+                color: selected ? theme.palette.secondary.contrastText : theme.palette.primary.contrastText,
+                backgroundColor: selected ? theme.palette.secondary.main : 'transparent',
+                fontSize: { xs: '0.68rem', sm: '0.72rem' },
+                lineHeight: 1.4,
+                textTransform: 'none',
+                '&:hover': {
+                  backgroundColor: selected ? theme.palette.secondary.light : theme.palette.action.hover,
+                },
+                '&:focus-visible': {
+                  outline: `2px solid ${theme.palette.secondary.light}`,
+                  outlineOffset: '-2px',
+                },
+              }}
+            >
+              {option.label}
+            </Button>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/App/AppTemplate/index.scss
+++ b/src/App/AppTemplate/index.scss
@@ -2,7 +2,7 @@
     position: fixed;
     top: 0;
     right: 0;
-    background-color: #244a8b;
+    background-color: var(--clc-header-bg, #244a8b);
     margin: auto;
     padding-top: 3px;
     text-align: center;

--- a/src/App/theme.tsx
+++ b/src/App/theme.tsx
@@ -1,0 +1,196 @@
+import {
+  createContext, ReactNode, useContext, useEffect, useMemo, useState,
+} from 'react';
+import {
+  createTheme, ThemeProvider as MuiThemeProvider,
+} from '@mui/material/styles';
+import { CssBaseline, GlobalStyles } from '@mui/material';
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+export type ResolvedThemeMode = 'light' | 'dark';
+
+const STORAGE_KEY = 'clc-theme-preference';
+const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)';
+
+const brand = {
+  blue: '#244a8b',
+  blueDark: '#14284d',
+  blueNight: '#0d1a33',
+  gold: '#f4c00e',
+  plum: '#2a222a',
+  linkBlue: '#88c1ff',
+  paperWarm: '#f7f9fc',
+};
+
+interface ThemePreferenceContextValue {
+  preference: ThemePreference;
+  resolvedMode: ResolvedThemeMode;
+  setPreference: (preference: ThemePreference) => void;
+}
+
+const ThemePreferenceContext = createContext<ThemePreferenceContextValue>({
+  preference: 'system',
+  resolvedMode: 'light',
+  setPreference: () => undefined,
+});
+
+export function getStoredThemePreference(storage: Storage | undefined = window.localStorage): ThemePreference {
+  try {
+    const value = storage?.getItem(STORAGE_KEY);
+    if (value === 'light' || value === 'dark' || value === 'system') return value;
+  } catch {
+    return 'system';
+  }
+  return 'system';
+}
+
+export function resolveThemeMode(preference: ThemePreference, systemPrefersDark: boolean): ResolvedThemeMode {
+  if (preference === 'system') return systemPrefersDark ? 'dark' : 'light';
+  return preference;
+}
+
+export function makeCollegeLutheranTheme(mode: ResolvedThemeMode) {
+  const darkMode = mode === 'dark';
+  return createTheme({
+    palette: {
+      mode,
+      primary: {
+        main: brand.blue,
+        light: '#5478b7',
+        dark: brand.blueDark,
+        contrastText: '#ffffff',
+      },
+      secondary: {
+        main: brand.gold,
+        light: '#ffe27a',
+        dark: '#9f7b00',
+        contrastText: '#1e1a0a',
+      },
+      background: {
+        default: darkMode ? brand.blueNight : '#ffffff',
+        paper: darkMode ? '#182848' : brand.paperWarm,
+      },
+      text: {
+        primary: darkMode ? '#eef4ff' : '#212529',
+        secondary: darkMode ? '#c9d6eb' : '#4c5664',
+      },
+      divider: darkMode ? 'rgba(244, 192, 14, 0.26)' : 'rgba(36, 74, 139, 0.18)',
+      error: {
+        main: darkMode ? '#ff8a80' : '#c62828',
+      },
+      action: {
+        hover: darkMode ? 'rgba(244, 192, 14, 0.12)' : 'rgba(36, 74, 139, 0.08)',
+        selected: darkMode ? 'rgba(244, 192, 14, 0.18)' : 'rgba(36, 74, 139, 0.12)',
+        focus: darkMode ? 'rgba(244, 192, 14, 0.34)' : 'rgba(36, 74, 139, 0.28)',
+        disabledBackground: darkMode ? 'rgba(201, 214, 235, 0.16)' : 'rgba(0, 0, 0, 0.12)',
+      },
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            backgroundColor: darkMode ? brand.blueNight : '#ffffff',
+            color: darkMode ? '#eef4ff' : '#212529',
+          },
+          'a, a:not([href]):not([tabindex])': {
+            color: darkMode ? brand.linkBlue : '#23527c',
+          },
+          'a:hover, a:not([href]):not([tabindex]):hover': {
+            color: darkMode ? '#cce0ff' : '#0056b3',
+          },
+          'button:focus-visible, a:focus-visible, [role="button"]:focus-visible': {
+            outline: `3px solid ${darkMode ? brand.gold : brand.blue}`,
+            outlineOffset: '2px',
+          },
+          '@media (prefers-reduced-motion: reduce)': {
+            '*, *::before, *::after': {
+              animationDuration: '0.01ms !important',
+              animationIterationCount: '1 !important',
+              scrollBehavior: 'auto !important',
+              transitionDuration: '0.01ms !important',
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+function themeVariables(mode: ResolvedThemeMode) {
+  const darkMode = mode === 'dark';
+  return {
+    ':root': {
+      colorScheme: mode,
+      '--clc-header-bg': darkMode ? brand.plum : brand.blue,
+      '--clc-header-text': '#ffffff',
+      '--clc-brand-gold': brand.gold,
+      '--clc-page-bg': darkMode ? brand.blueNight : '#ffffff',
+      '--clc-paper-bg': darkMode ? '#182848' : brand.paperWarm,
+      '--clc-drawer-bg': darkMode ? '#111a2c' : '#c0c0c0',
+      '--clc-drawer-hover': darkMode ? 'rgba(244, 192, 14, 0.12)' : '#ffffff',
+      '--clc-text-primary': darkMode ? '#eef4ff' : '#212529',
+      '--clc-text-secondary': darkMode ? '#c9d6eb' : '#4c5664',
+      '--clc-link': darkMode ? brand.linkBlue : '#23527c',
+      '--clc-link-hover': darkMode ? '#cce0ff' : '#0056b3',
+      '--clc-border': darkMode ? 'rgba(244, 192, 14, 0.26)' : 'rgba(36, 74, 139, 0.18)',
+      '--clc-caption-bg': darkMode ? '#22345d' : '#c0c0c0',
+      '--clc-danger': darkMode ? '#ff8a80' : '#c62828',
+    },
+  };
+}
+
+export function CollegeLutheranThemeProvider({ children }: { children: ReactNode }) {
+  const [preference, setPreferenceState] = useState<ThemePreference>(() => getStoredThemePreference());
+  const [systemPrefersDark, setSystemPrefersDark] = useState(() => (
+    window.matchMedia?.(SYSTEM_DARK_QUERY).matches ?? false
+  ));
+  const resolvedMode = resolveThemeMode(preference, systemPrefersDark);
+  const theme = useMemo(() => makeCollegeLutheranTheme(resolvedMode), [resolvedMode]);
+
+  useEffect(() => {
+    const media = window.matchMedia?.(SYSTEM_DARK_QUERY);
+    if (!media) return undefined;
+    const updateSystemMode = (event: MediaQueryListEvent | MediaQueryList) => setSystemPrefersDark(event.matches);
+    updateSystemMode(media);
+    media.addEventListener?.('change', updateSystemMode);
+    media.addListener?.(updateSystemMode);
+    return () => {
+      media.removeEventListener?.('change', updateSystemMode);
+      media.removeListener?.(updateSystemMode);
+    };
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.dataset.themePreference = preference;
+    document.documentElement.dataset.themeMode = resolvedMode;
+  }, [preference, resolvedMode]);
+
+  const setPreference = (nextPreference: ThemePreference) => {
+    setPreferenceState(nextPreference);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, nextPreference);
+    } catch {
+      // Storage can be unavailable in private contexts; the in-memory choice still applies.
+    }
+  };
+
+  const contextValue = useMemo(() => ({
+    preference,
+    resolvedMode,
+    setPreference,
+  }), [preference, resolvedMode]);
+
+  return (
+    <ThemePreferenceContext.Provider value={contextValue}>
+      <MuiThemeProvider theme={theme}>
+        <CssBaseline />
+        <GlobalStyles styles={themeVariables(resolvedMode)} />
+        {children}
+      </MuiThemeProvider>
+    </ThemePreferenceContext.Provider>
+  );
+}
+
+export function useThemePreference() {
+  return useContext(ThemePreferenceContext);
+}

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -10,6 +10,7 @@ import { AuthProvider } from './providers/Auth.provider';
 import './styles/styles.scss';
 import { ContentProvider } from './providers/Content.provider';
 import { BrowserRouter } from 'react-router-dom';
+import { CollegeLutheranThemeProvider } from './App/theme';
 
 const root = createRoot(document.getElementById('root') as HTMLElement);
 function Main() {
@@ -19,10 +20,12 @@ function Main() {
         <Provider store={store.store}>
           <PersistGate loading={null} persistor={store.persistor}>
             <ContentProvider>
-              <ToastContainer position="top-right" autoClose={5000} />
-              <BrowserRouter>
-                <App />
-              </BrowserRouter>
+              <CollegeLutheranThemeProvider>
+                <ToastContainer position="top-right" autoClose={5000} />
+                <BrowserRouter>
+                  <App />
+                </BrowserRouter>
+              </CollegeLutheranThemeProvider>
             </ContentProvider>
           </PersistGate>
         </Provider>

--- a/src/components/PicSlider/caption.tsx
+++ b/src/components/PicSlider/caption.tsx
@@ -1,7 +1,9 @@
 import type React from 'react';
+import { useTheme } from '@mui/material/styles';
 
 export const Caption = (props: { caption?: (React.JSX.Element | string); }): React.JSX.Element => {
   const { caption } = props;
+  const theme = useTheme();
   return (
     <div
       className="slider-caption"
@@ -9,7 +11,8 @@ export const Caption = (props: { caption?: (React.JSX.Element | string); }): Rea
         textAlign: 'center',
         fontWeight: 'bold',
         padding: 0,
-        backgroundColor: 'silver',
+        backgroundColor: theme.palette.background.paper,
+        color: theme.palette.text.primary,
         marginBottom: 0,
         marginTop: 0,
       }}

--- a/src/containers/AdminDashboard/EditPic/EditPicDialog.tsx
+++ b/src/containers/AdminDashboard/EditPic/EditPicDialog.tsx
@@ -86,7 +86,7 @@ export function EditPicDialog({ editPic, setEditPic, onClose }: IeditPicDialogPr
             Update
           </Button>
           <Button
-            style={{ color: 'red' }}
+            sx={{ color: 'error.main' }}
             size="small"
             className="deletePicButton"
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -106,4 +106,3 @@ export function EditPicDialog({ editPic, setEditPic, onClose }: IeditPicDialogPr
     </Dialog>
   );
 }
-

--- a/src/containers/Beliefs/BeliefsContent.tsx
+++ b/src/containers/Beliefs/BeliefsContent.tsx
@@ -7,7 +7,7 @@ const BeliefsContent = () => (
       <div className="material-content elevation3" style={{ maxWidth: '998px', paddingBottom: '-80px', margin: 'auto' }}>
         <h3 style={{ paddingBottom: '15px', paddingTop: '22px' }}>Our Lutheran Beliefs</h3>
         <p>
-          <span style={{ color: 'rgb(0, 51, 102)' }}>
+          <span className="brand-emphasis">
             <strong>We believe that the Holy Bible is God&rsquo;s inspired Word.</strong>
           </span>
           <strong>&nbsp;</strong>
@@ -15,56 +15,56 @@ const BeliefsContent = () => (
           light of the revelation of Jesus Christ.
         </p>
         <p>
-          <span style={{ color: 'rgb(0, 51, 102)' }}>
+          <span className="brand-emphasis">
             <strong>We believe that God created us and all that exists.</strong>
             &nbsp;
           </span>
           He has given us all that we have and need. We, therefore, are called by him to care for all that he has made, especially one another.
         </p>
         <p>
-          <span style={{ color: 'rgb(0, 51, 102)' }}>
+          <span className="brand-emphasis">
             <strong>We believe that Jesus Christ is the Son of God.</strong>
           </span>
           &nbsp;He is our Savior, who was born into our world, lived among us, was crucified for our sins, and rose again from the dead. We believe he
           is present with us even now. We especially know his presence in the proclamation of the Word through preaching and Holy Communion.
         </p>
         <p>
-          <span style={{ color: 'rgb(0, 51, 102)' }}>
+          <span className="brand-emphasis">
             <strong>We believe that the Holy Spirit has been given to us.</strong>
           </span>
           &nbsp;The Spirit enlightens and sustains us as Christ&rsquo;s Church on earth. It is through the gift of the Holy Spirit received in Baptism
           that we are born again, able to have faith and remain in a loving relationship with God.
         </p>
         <p>
-          <span style={{ color: 'rgb(0, 51, 102)' }}>
+          <span className="brand-emphasis">
             <strong>We believe we are saved by grace through faith.</strong>
           </span>
           &nbsp;Our salvation depends solely on God&rsquo;s grace and not on our merit or works. At the same time, God&rsquo;s free gift of grace
           leads us to respond with lives and works that are pleasing to him.
         </p>
         <p>
-          <span style={{ color: 'rgb(0, 51, 102)' }}>
+          <span className="brand-emphasis">
             <strong>We believe we are called to mission.</strong>
           </span>
           &nbsp;We take seriously God&rsquo;s expectation that we are to reach out with the good news of God&rsquo;s saving grace to all people, and
           that we are to care for those in need.
         </p>
         <p>
-          <span style={{ color: 'rgb(0, 51, 102)' }}>
+          <span className="brand-emphasis">
             <strong>We believe Christ is truly present in Holy Communion.&nbsp;</strong>
           </span>
           The Sacrament of the Altar is far more than a memorial meal; it is that appointed time and place when Christ has promised to be present and
           the forgiveness of sins is assured.
         </p>
         <p>
-          <span style={{ color: 'rgb(0, 51, 102)' }}>
+          <span className="brand-emphasis">
             <strong>We accept the Apostles&rsquo; and Nicene Creeds.</strong>
             &nbsp;
           </span>
           These are true and accurate statements of what we believe.
         </p>
         <p>
-          <span style={{ color: 'rgb(0, 51, 102)' }}>
+          <span className="brand-emphasis">
             <strong>We believe in the power of prayer.</strong>
           </span>
           &nbsp;Through prayer we may be in conversation with the God who loves us, hears us in our need and responds to us.

--- a/src/containers/Family/FamilyContent.tsx
+++ b/src/containers/Family/FamilyContent.tsx
@@ -54,7 +54,7 @@ export const FamilyContent = () => {
         <div className="material-content elevation3" style={{ maxWidth: '998px', paddingBottom: '-80px', margin: 'auto' }}>
           <h3 style={{ paddingBottom: '15px' }}>Children and Families</h3>
           <p>
-            <span style={{ color: 'rgb(0, 51, 102)' }}>
+            <span className="brand-emphasis">
               <strong>
                 <i>&quot;The members of the body that seem to be weaker are indispensable.&quot;</i>
                 &nbsp;&nbsp;&nbsp;1 Corinthians 12:22

--- a/src/containers/Homepage/FacebookPosts.tsx
+++ b/src/containers/Homepage/FacebookPosts.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTheme } from '@mui/material/styles';
 
 // Cards rendered from web-jam-back's cached Graph API feed
 // (GET /facebook/feed), replacing the unreliable Page Plugin iframe
@@ -21,6 +22,7 @@ const STALE_MS = 7 * 24 * 60 * 60 * 1000;
 export interface FacebookPostsProps { maxWidth?: number; maxHeight?: number; testId?: string }
 
 export const FacebookPosts = ({ maxWidth = 500, maxHeight = 485, testId }: FacebookPostsProps) => {
+  const theme = useTheme();
   const [posts, setPosts] = useState<FbPost[]>([]);
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   useEffect(() => {
@@ -61,7 +63,8 @@ export const FacebookPosts = ({ maxWidth = 500, maxHeight = 485, testId }: Faceb
               display: 'block',
               textDecoration: 'none',
               color: 'inherit',
-              border: '1px solid #ddd',
+              border: `1px solid ${theme.palette.divider}`,
+              backgroundColor: theme.palette.background.paper,
               borderRadius: '6px',
               padding: '8px',
               marginBottom: '10px',
@@ -72,7 +75,7 @@ export const FacebookPosts = ({ maxWidth = 500, maxHeight = 485, testId }: Faceb
             ) : null}
             {post.message ? <p style={{ fontSize: '10pt', margin: '0 0 4px' }}>{post.message}</p> : null}
             {post.created_time ? (
-              <span style={{ fontSize: '8pt', color: '#666' }}>
+              <span style={{ fontSize: '8pt', color: theme.palette.text.secondary }}>
                 {new Date(post.created_time).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
               </span>
             ) : null}
@@ -80,7 +83,7 @@ export const FacebookPosts = ({ maxWidth = 500, maxHeight = 485, testId }: Faceb
         ))}
       </div>
       {lastUpdated ? (
-        <p className="fbUpdated" style={{ fontSize: '8pt', color: '#666', textAlign: 'center', margin: '4px 0 0' }}>
+        <p className="fbUpdated" style={{ fontSize: '8pt', color: theme.palette.text.secondary, textAlign: 'center', margin: '4px 0 0' }}>
           {`Feed updated ${new Date(lastUpdated).toLocaleString()}`}
         </p>
       ) : null}

--- a/src/containers/News/EditNewsDialog.tsx
+++ b/src/containers/News/EditNewsDialog.tsx
@@ -107,7 +107,11 @@ export function EditNewsButtons(props: IeditNewsDialogProps) {
           {loading ? <CircularProgress size={20} color="inherit" className="newsSubmitSpinner" /> : 'Update'}
         </Button>
         <Button
-          style={{ backgroundColor: 'red', color: 'white' }}
+          sx={{
+            backgroundColor: 'error.main',
+            color: 'error.contrastText',
+            '&:hover': { backgroundColor: 'error.dark' },
+          }}
           disabled={loading}
           size="small"
           className="deleteNewsButton"
@@ -144,4 +148,3 @@ export function EditNewsDialog({ editNews, setEditNews }: IeditNewsDialogProps) 
     </Dialog>
   );
 }
-

--- a/src/containers/Youth/YouthContent.tsx
+++ b/src/containers/Youth/YouthContent.tsx
@@ -7,7 +7,7 @@ function FaithWithoutWorks() {
   return (
     <>
       <p>
-        <span style={{ color: 'rgb(0, 51, 102)' }}>
+        <span className="brand-emphasis">
           <strong>
             <i>&quot;Faith without works is dead.&quot;</i>
             &nbsp;&nbsp;&nbsp;James 2:17
@@ -44,7 +44,7 @@ export const YouthContent = (
         <div className="material-content elevation3" style={{ maxWidth: '998px', paddingBottom: '-80px', margin: 'auto' }}>
           <h3 style={{ paddingTop: '22px', paddingBottom: '15px' }}>Youth Ministry</h3>
           <p>
-            <span style={{ color: 'rgb(0, 51, 102)' }}>
+            <span className="brand-emphasis">
               <strong>
                 <i>&quot;Think of us in this way, as servants of Christ and stewards of God’s mysteries.&quot;</i>
                 &nbsp;&nbsp;&nbsp;1 Corinthians 4:1
@@ -84,4 +84,3 @@ export const YouthContent = (
 };
 
 export default YouthContent;
-

--- a/src/styles/_MuiTheme.scss
+++ b/src/styles/_MuiTheme.scss
@@ -5,7 +5,7 @@
 th.MuiTableCell-root.MuiTableCell-head.MUIDataTableHeadCell-root-64 {
   padding: 4px;
   font-weight: bold;
-  color: black;
+  color: var(--clc-text-primary, black);
   font-size: 11pt;
 }
 

--- a/src/styles/_footer.scss
+++ b/src/styles/_footer.scss
@@ -3,37 +3,37 @@
 }
 
 .footerIcon:hover {
-  color: white;
+  color: var(--clc-header-text, white);
 }
 
 .footer {
   flex-shrink: 0;
-  background-color: rgb(36, 74, 139) !important;
+  background-color: var(--clc-header-bg, rgb(36, 74, 139)) !important;
 }
 
 .footer span {
-  color: #f4c00eff;
+  color: var(--clc-brand-gold, #f4c00eff);
   cursor: pointer;
 }
 
 .footer span:hover {
-  color: #ffffff;
+  color: var(--clc-header-text, #ffffff);
   cursor: pointer;
 }
 
 .wjllc {
-  color: white;
+  color: var(--clc-header-text, white);
   font-size: 9pt;
   font-weight: bold;
 }
 
 .wjllc:hover {
-  color: black;
+  color: var(--clc-brand-gold, black);
 }
 
 .nohover {
   margin-left: 26px;
-  color: #fff !important;
+  color: var(--clc-header-text, #fff) !important;
   font-size: 9pt;
   margin-bottom: 0;
   cursor: text !important;

--- a/src/styles/_materialui.scss
+++ b/src/styles/_materialui.scss
@@ -2,10 +2,14 @@
 
 .material-content {
   padding: 10px;
+  background-color: var(--clc-paper-bg, transparent);
+  color: var(--clc-text-primary, inherit);
 }
 
 .material-content-faq {
   padding: 10px;
+  background-color: var(--clc-paper-bg, transparent);
+  color: var(--clc-text-primary, inherit);
 }
 
 .material-content-h1,
@@ -21,7 +25,7 @@
 
 .material-content-h1 {
   font-size: 34px;
-  color: black;
+  color: var(--clc-text-primary, black);
 }
 
 .material-content-p {
@@ -46,7 +50,7 @@
 
 .material-header {
   min-height: 88px;
-  background-color: #244a8bff;
+  background-color: var(--clc-header-bg, #244a8bff);
   z-index: 93;
   top: 0;
 }
@@ -58,11 +62,11 @@
 }
 
 .material-header-h3 {
-  color: white;
+  color: var(--clc-header-text, white);
 }
 
 .material-header-h3-call {
-  color: white;
+  color: var(--clc-header-text, white);
   font-size: 22pt;
 }
 

--- a/src/styles/_menu.scss
+++ b/src/styles/_menu.scss
@@ -1,30 +1,30 @@
 .nav-link {
   padding-left: 0;
   display     : block !important;
-  color       : #23527c;
+  color       : var(--clc-link, #23527c);
   outline     : none !important;
 }
 
 button.nav-link {
-  background-color: rgb(192, 192, 192);
+  background-color: var(--clc-drawer-bg, rgb(192, 192, 192));
   font-size       : 16px;
   border          : none;
   padding         : 14px 0;
 }
 
 button.nav-link:hover {
-  background-color: white;
+  background-color: var(--clc-drawer-hover, white);
 }
 
 .nav-item {
-  color          : #23527c;
+  color          : var(--clc-link, #23527c);
   text-decoration: underline;
   padding-right  : 0;
   margin-right   : 0;
 }
 
 .menu-item:hover {
-  background-color: white;
+  background-color: var(--clc-drawer-hover, white);
 }
 
 .menu-item {
@@ -55,8 +55,8 @@ button.nav-link:hover {
   left           : 90vw;
   top             : 34px;
   z-index: 50;
-  color           : #f4c00eff;
-  background-color: #244a8bff;
+  color           : var(--clc-brand-gold, #f4c00eff);
+  background-color: var(--clc-header-bg, #244a8bff);
   padding         : 1px 6px 0;
 }
 
@@ -69,16 +69,16 @@ button.nav-link:hover {
   position        : fixed;
   top             : 32px;
   right           : 16px;
-  background-color: #2a222a;
-  color           : white;
+  background-color: var(--clc-header-bg, #2a222a);
+  color           : var(--clc-header-text, white);
   padding         : 6px;
   z-index         : 90000;
 }
 
 .menu-item a.menu-hover {
-  color: '#88c1ff' !important;
+  color: var(--clc-link, #88c1ff) !important;
 }
 
 .menu-hover:hover {
-  color: rgb(204, 224, 255) !important;
+  color: var(--clc-link-hover, rgb(204, 224, 255)) !important;
 }

--- a/src/styles/_menu.scss
+++ b/src/styles/_menu.scss
@@ -53,8 +53,8 @@ button.nav-link:hover {
   cursor          : pointer;
   position        : absolute;
   left           : 90vw;
-  top             : 34px;
-  z-index: 50;
+  top             : 8px;
+  z-index: 100;
   color           : var(--clc-brand-gold, #f4c00eff);
   background-color: var(--clc-header-bg, #244a8bff);
   padding         : 1px 6px 0;

--- a/src/styles/_mobile.scss
+++ b/src/styles/_mobile.scss
@@ -36,7 +36,7 @@
 
   .page-content {
     flex: 1 0 auto;
-    border-right: 1px solid #000000;
+    border-right: 1px solid var(--clc-border, #000000);
   }
 
   ::-webkit-scrollbar:vertical {
@@ -46,7 +46,7 @@
   .newsIFrame {
     width:350px;
     height: 610px;
-    border: 1px solid #d3d3d3;
+    border: 1px solid var(--clc-border, #d3d3d3);
   }
 }
 
@@ -293,7 +293,7 @@
   }
 
   .drawer {
-    background-color: rgb(192, 192, 192);
+    background-color: var(--clc-drawer-bg, rgb(192, 192, 192));
     float: right;
     height: 100%;
   }
@@ -357,7 +357,7 @@
     display: block !important;
     width: 100vw !important;
     z-index: 100 !important;
-    background-color: rgba(42, 34, 42, 0.67);
+    background-color: color-mix(in srgb, var(--clc-header-bg, #2a222a) 67%, transparent);
   }
 
   .content-block {
@@ -412,7 +412,7 @@
   height: 86vh;
   overflow-x: hidden;
   z-index: 90000;
-  background-color: rgb(192, 192, 192);
+  background-color: var(--clc-drawer-bg, rgb(192, 192, 192));
   overflow-y: auto;
   -webkit-appearance: none;
   -ms-overflow-style: none;  /* Internet Explorer 10+ */
@@ -424,7 +424,7 @@
     position: fixed;
     top: 0;
     right: 0;
-    background-color: #244a8bff;
+    background-color: var(--clc-header-bg, #244a8bff);
     margin: auto;
     padding-top: 3px;
     text-align: center;

--- a/src/styles/_mobile.scss
+++ b/src/styles/_mobile.scss
@@ -239,7 +239,7 @@
 @media (min-width: 400px) and (max-width: 419px) {
 
   .flex-header {
-    width: 100% !important;
+    width: calc(100% - 150px) !important;
   }
 
   img#elcaLogo {

--- a/src/styles/_news.scss
+++ b/src/styles/_news.scss
@@ -9,7 +9,7 @@
 .newsTable {
     width: 320px;
     margin-bottom: 1rem;
-    color: #212529;
+    color: var(--clc-text-primary, #212529);
     table-layout: fixed;
 }
 
@@ -23,12 +23,12 @@
 
 .newsUrl tbody tr:nth-child(odd) {
   display: table-row;
-  background-color: #d8ecf3;
+  background-color: color-mix(in srgb, var(--clc-link, #d8ecf3) 18%, var(--clc-paper-bg, #ffffff));
 }
 
 .newsUrl tbody tr:nth-child(even) {
   display: table-row;
-  background-color: #fff;
+  background-color: var(--clc-paper-bg, #fff);
 }
 
 @media screen and (max-width: 320px) {
@@ -60,7 +60,7 @@
   max-width: 32rem;
   margin: 1rem auto;
   padding: 0 1rem;
-  color: #444;
+  color: var(--clc-text-secondary, #444);
   font-size: 1rem;
   line-height: 1.5;
 }

--- a/src/styles/_slideshow.scss
+++ b/src/styles/_slideshow.scss
@@ -57,12 +57,12 @@
 #familySlideshowWide img, #familySlideshow1 img, #youthSlideshowWide img, #youthSlideshowWide1 img {
   margin: auto;
   max-height: 5in;
-  padding-top: 1px
+  padding-top: 1px;
 }
 
 .slide-show {
   height: 400px;
   width: 100%;
   object-fit: contain;
-  background-color: rgb(192, 192, 192);
+  background-color: var(--clc-caption-bg, rgb(192, 192, 192));
 }

--- a/src/styles/_tables.scss
+++ b/src/styles/_tables.scss
@@ -8,16 +8,16 @@ table {
 }
 
 tbody tr:nth-child(odd) {
-  background-color: #d8ecf3;
+  background-color: color-mix(in srgb, var(--clc-link, #d8ecf3) 18%, var(--clc-paper-bg, #ffffff));
 }
 
 tbody.regformtbody tr:nth-child(odd) {
-  background-color: white;
+  background-color: var(--clc-paper-bg, white);
 }
 
 th, td {
   border-collapse: collapse;
-  border: 1px solid #777;
+  border: 1px solid var(--clc-border, #777);
   padding: 8px;
   text-align: left;
 }
@@ -45,8 +45,8 @@ tbody.regformtbody td {
 
 .TableStyle-root {
   width: 80%;
-  color: rgba(0, 0, 0, 0.87);
-  background-color: #fff;
+  color: var(--clc-text-primary, rgba(0, 0, 0, 0.87));
+  background-color: var(--clc-paper-bg, #fff);
   display: flex;
   flex-direction: column;
   align-self: center;
@@ -84,11 +84,11 @@ tbody.regformtbody td {
   left: 0;
   z-index: 2;
   position: sticky;
-  background-color: #fff;
+  background-color: var(--clc-paper-bg, #fff);
 }
 
 .TableCell-head {
-  color: rgba(0, 0, 0, 0.87);
+  color: var(--clc-text-primary, rgba(0, 0, 0, 0.87));
   font-weight: bold;
   line-height: 1.5rem;
 }
@@ -98,7 +98,7 @@ tbody.regformtbody td {
   padding: 8px;
   font-size: 0.875rem;
   text-align: left;
-  border-bottom: 1px solid rgba(224, 224, 224, 1);
+  border-bottom: 1px solid var(--clc-border, rgba(224, 224, 224, 1));
   letter-spacing: 0.02em;
   vertical-align: inherit;
 }
@@ -108,5 +108,5 @@ tbody.regformtbody td {
 }
 
 .TableCell-body {
-  color: rgba(0, 0, 0, 0.87);
+  color: var(--clc-text-primary, rgba(0, 0, 0, 0.87));
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -312,6 +312,25 @@ button:disabled {
   z-index: 60;
 }
 
+/* On phones the header is cramped: reserve the bottom-right corner so the
+   title/subtitle text wraps before it reaches the theme selector + hamburger. */
+@media screen and (max-width: 699px) {
+  /* Let the header grow to fit its content on phones so a wrapped title +
+     subtitle never spill out below the fixed height. */
+  .home-header {
+    height: auto;
+    min-height: 91px;
+  }
+
+  .flex-header {
+    width: calc(100% - 162px) !important;
+  }
+
+  .subTitle {
+    max-width: 100%;
+  }
+}
+
 .theme-mode-option + .theme-mode-option {
   border-left: 1px solid var(--clc-border, rgba(255, 255, 255, 0.28));
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -417,6 +417,13 @@ div.familyELCA, div.youthELCA, div.givingELCA, div.beliefsELCA, div.newsELCA {
   padding-top: 0;
 }
 
+html[data-theme-mode='dark'] #elcaLogo {
+  background: #ffffff;
+  border: 1px solid var(--clc-border, rgba(244, 192, 14, 0.26));
+  border-radius: 4px;
+  padding: 10px 12px;
+}
+
 .staffElca {
   text-align: left;
   margin-bottom: -30px;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -19,7 +19,8 @@ body {
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;
-  color: #212529;
+  color: var(--clc-text-primary, #212529);
+  background-color: var(--clc-page-bg, #ffffff);
   text-align: left;
 }
 
@@ -27,7 +28,7 @@ hr {
   margin-top: 1rem;
   margin-bottom: 1rem;
   border: 0;
-  border-top: 1px solid rgba(0, 0, 0, .1);
+  border-top: 1px solid var(--clc-border, rgba(0, 0, 0, .1));
 }
 
 p {
@@ -85,7 +86,7 @@ h5 {
 h6 {
   text-align: center;
   font-weight: bold;
-  color: black;
+  color: var(--clc-text-primary, black);
   font-style: italic;
   font-family: 'PT Sans Caption';
 }
@@ -146,7 +147,7 @@ select {
 }
 
 .header-text {
-  color: white;
+  color: var(--clc-header-text, white);
   font-size: 19pt;
   font-weight: 500;
   font-family: 'TrajanProRegular', Times, 'Times New Roman', serif;
@@ -159,13 +160,14 @@ select {
 }
 
 .home-sidebar {
-  background-color: #c0c0c0;
+  background-color: var(--clc-drawer-bg, #c0c0c0);
 }
 
 .home-header {
-  background-color: #2a222a;
+  background-color: var(--clc-header-bg, #2a222a);
   /* margin: 0; */
   height: 91px;
+  position: relative;
 }
 
 .home-header-image {
@@ -173,7 +175,7 @@ select {
 }
 
 .home-menu-toggle {
-  color: #333;
+  color: var(--clc-text-primary, #333);
 }
 
 .flex-header {
@@ -189,7 +191,7 @@ select {
   max-width: 80%;
   font-weight: bold;
   font-size: 16px;
-  color: #999999;
+  color: var(--clc-brand-gold, #999999);
   font-family: 'Trebuchet MS', 'ChivoBlack', Arial, Helvetica, sans-serif;
 }
 
@@ -220,12 +222,12 @@ select {
 
 a:not([href]):not([tabindex]) {
   text-decoration: underline;
-  color: #007bff;
+  color: var(--clc-link, #007bff);
 }
 
 a:not([href]):not([tabindex]):hover {
   text-decoration: underline;
-  color: #0056b3;
+  color: var(--clc-link-hover, #0056b3);
 }
 
 p, a, label {
@@ -241,11 +243,15 @@ a {
 }
 
 a:hover {
-  color: #0056b3;
+  color: var(--clc-link-hover, #0056b3);
 }
 
 .regularLink {
   text-decoration: underline;
+}
+
+.brand-emphasis {
+  color: var(--clc-link, rgb(0, 51, 102));
 }
 
 /* Buttons */
@@ -255,45 +261,59 @@ button {
 }
 
 button:hover {
-  background-color: #ddffcc;
+  background-color: var(--clc-drawer-hover, #ddffcc);
 
 }
 
 button:disabled {
-  background-color: #f2f2f2;
-  cursor: none
+  background-color: color-mix(in srgb, var(--clc-text-secondary, #4c5664) 16%, transparent);
+  cursor: none;
 }
 
 .button-lib {
   height: 0.35in;
   text-transform: none;
   margin: 20px 6cm 0;
-  background-color: #c0c0c0;
+  background-color: var(--clc-caption-bg, #c0c0c0);
   border-width: thin;
   border-style: outset;
-  border-color: #8c8c8c;
+  border-color: var(--clc-border, #8c8c8c);
 }
 
 .button-checkout {
   height: 0.35in;
   width: 0.95in;
   text-transform: none;
-  background-color: black;
+  background-color: var(--clc-text-primary, black);
   border-width: thin;
   border-style: outset;
-  border-color: #737373;
-  color: white;
+  border-color: var(--clc-border, #737373);
+  color: var(--clc-page-bg, white);
 }
 
 .button-checkin {
   height: 0.35in;
   width: 0.95in;
   text-transform: none;
-  background-color: #88bde6;
+  background-color: var(--clc-link, #88bde6);
   border-width: thin;
   border-style: outset;
-  border-color: #2d8bd2;
-  color: black;
+  border-color: var(--clc-link-hover, #2d8bd2);
+  color: var(--clc-page-bg, black);
+}
+
+.theme-mode-selector {
+  display: inline-flex;
+  overflow: hidden;
+  border-radius: 999px;
+  position: absolute;
+  right: 14px;
+  bottom: 10px;
+  z-index: 60;
+}
+
+.theme-mode-option + .theme-mode-option {
+  border-left: 1px solid var(--clc-border, rgba(255, 255, 255, 0.28));
 }
 
 /* Keyframes */
@@ -370,7 +390,7 @@ div.fof {
   width: 100%;
   max-width: 800px;
   height: 750px;
-  border: 1px solid #d3d3d3;
+  border: 1px solid var(--clc-border, #d3d3d3);
 }
 
 /* App/Staff */

--- a/test/App/theme.spec.tsx
+++ b/test/App/theme.spec.tsx
@@ -1,0 +1,89 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+  CollegeLutheranThemeProvider,
+  getStoredThemePreference,
+  resolveThemeMode,
+  useThemePreference,
+} from 'src/App/theme';
+import { ThemeModeSelector } from 'src/App/AppTemplate/ThemeModeSelector';
+
+function ThemeState() {
+  const { preference, resolvedMode } = useThemePreference();
+  return (
+    <div>
+      <span data-testid="preference">{preference}</span>
+      <span data-testid="resolvedMode">{resolvedMode}</span>
+      <ThemeModeSelector />
+    </div>
+  );
+}
+
+function installMatchMedia(matches: boolean) {
+  let listener: ((event: MediaQueryListEvent) => void) | undefined;
+  const media = {
+    matches,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: vi.fn((_event: string, nextListener: (event: MediaQueryListEvent) => void) => {
+      listener = nextListener;
+    }),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn((nextListener: (event: MediaQueryListEvent) => void) => {
+      listener = nextListener;
+    }),
+    removeListener: vi.fn(),
+    dispatch(nextMatches: boolean) {
+      this.matches = nextMatches;
+      listener?.({ matches: nextMatches } as MediaQueryListEvent);
+    },
+  };
+  window.matchMedia = vi.fn().mockReturnValue(media);
+  return media;
+}
+
+describe('CollegeLutheranThemeProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to system and resolves from prefers-color-scheme', () => {
+    installMatchMedia(true);
+    render(<CollegeLutheranThemeProvider><ThemeState /></CollegeLutheranThemeProvider>);
+    expect(screen.getByTestId('preference').textContent).toBe('system');
+    expect(screen.getByTestId('resolvedMode').textContent).toBe('dark');
+    expect(document.documentElement.dataset.themeMode).toBe('dark');
+  });
+
+  it('reads only valid stored preferences', () => {
+    localStorage.setItem('clc-theme-preference', 'dark');
+    expect(getStoredThemePreference()).toBe('dark');
+    localStorage.setItem('clc-theme-preference', 'invalid');
+    expect(getStoredThemePreference()).toBe('system');
+  });
+
+  it('keeps system mode live when the OS preference changes', () => {
+    const media = installMatchMedia(false);
+    render(<CollegeLutheranThemeProvider><ThemeState /></CollegeLutheranThemeProvider>);
+    expect(screen.getByTestId('resolvedMode').textContent).toBe('light');
+    act(() => { media.dispatch(true); });
+    expect(screen.getByTestId('resolvedMode').textContent).toBe('dark');
+  });
+
+  it('persists explicit selector choices', () => {
+    installMatchMedia(false);
+    render(<CollegeLutheranThemeProvider><ThemeState /></CollegeLutheranThemeProvider>);
+    fireEvent.click(screen.getByRole('button', { name: 'Dark' }));
+    expect(screen.getByTestId('preference').textContent).toBe('dark');
+    expect(screen.getByTestId('resolvedMode').textContent).toBe('dark');
+    expect(localStorage.getItem('clc-theme-preference')).toBe('dark');
+  });
+});
+
+describe('resolveThemeMode', () => {
+  it('resolves explicit and system preferences', () => {
+    expect(resolveThemeMode('light', true)).toBe('light');
+    expect(resolveThemeMode('dark', false)).toBe('dark');
+    expect(resolveThemeMode('system', true)).toBe('dark');
+    expect(resolveThemeMode('system', false)).toBe('light');
+  });
+});

--- a/test/components/__snapshots__/index.spec.tsx.snap
+++ b/test/components/__snapshots__/index.spec.tsx.snap
@@ -55,7 +55,7 @@ exports[`PicSlider > renders with a caption 1`] = `
                 />
                 <div
                   class="slider-caption"
-                  style="text-align: center; font-weight: bold; padding: 0px; background-color: silver; margin-bottom: 0px; margin-top: 0px;"
+                  style="text-align: center; font-weight: bold; padding: 0px; background-color: rgb(255, 255, 255); color: rgba(0, 0, 0, 0.87); margin-bottom: 0px; margin-top: 0px;"
                 >
                    
                   test2

--- a/test/containers/AdminDashboard/EditPic/__snapshots__/EditPicDialog.spec.tsx.snap
+++ b/test/containers/AdminDashboard/EditPic/__snapshots__/EditPicDialog.spec.tsx.snap
@@ -82,7 +82,7 @@ exports[`EditPicDialog > renders EditPicDialog 1`] = `
       </button>
       <button
         class="deletePicButton"
-        style="color: red;"
+        sx="[object Object]"
       >
         Delete
       </button>

--- a/test/containers/AdminDashboard/EditPic/__snapshots__/EditPicTable.spec.tsx.snap
+++ b/test/containers/AdminDashboard/EditPic/__snapshots__/EditPicTable.spec.tsx.snap
@@ -630,7 +630,7 @@ exports[`EditPicTable > renders EditPicTable 1`] = `
         </button>
         <button
           class="deletePicButton"
-          style="color: red;"
+          sx="[object Object]"
         >
           Delete
         </button>

--- a/test/containers/Beliefs/__snapshots__/BeliefsContent.spec.tsx.snap
+++ b/test/containers/Beliefs/__snapshots__/BeliefsContent.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`BeliefsContent > renders the beliefs page 1`] = `
         </h3>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe that the Holy Bible is God’s inspired Word.
@@ -37,7 +37,7 @@ exports[`BeliefsContent > renders the beliefs page 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe that God created us and all that exists.
@@ -48,7 +48,7 @@ exports[`BeliefsContent > renders the beliefs page 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe that Jesus Christ is the Son of God.
@@ -58,7 +58,7 @@ exports[`BeliefsContent > renders the beliefs page 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe that the Holy Spirit has been given to us.
@@ -68,7 +68,7 @@ exports[`BeliefsContent > renders the beliefs page 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe we are saved by grace through faith.
@@ -78,7 +78,7 @@ exports[`BeliefsContent > renders the beliefs page 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe we are called to mission.
@@ -88,7 +88,7 @@ exports[`BeliefsContent > renders the beliefs page 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe Christ is truly present in Holy Communion. 
@@ -98,7 +98,7 @@ exports[`BeliefsContent > renders the beliefs page 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We accept the Apostles’ and Nicene Creeds.
@@ -109,7 +109,7 @@ exports[`BeliefsContent > renders the beliefs page 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe in the power of prayer.

--- a/test/containers/Beliefs/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Beliefs/__snapshots__/index.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`Beliefs > renders correctly 1`] = `
         </h3>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe that the Holy Bible is God’s inspired Word.
@@ -37,7 +37,7 @@ exports[`Beliefs > renders correctly 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe that God created us and all that exists.
@@ -48,7 +48,7 @@ exports[`Beliefs > renders correctly 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe that Jesus Christ is the Son of God.
@@ -58,7 +58,7 @@ exports[`Beliefs > renders correctly 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe that the Holy Spirit has been given to us.
@@ -68,7 +68,7 @@ exports[`Beliefs > renders correctly 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe we are saved by grace through faith.
@@ -78,7 +78,7 @@ exports[`Beliefs > renders correctly 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe we are called to mission.
@@ -88,7 +88,7 @@ exports[`Beliefs > renders correctly 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe Christ is truly present in Holy Communion. 
@@ -98,7 +98,7 @@ exports[`Beliefs > renders correctly 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We accept the Apostles’ and Nicene Creeds.
@@ -109,7 +109,7 @@ exports[`Beliefs > renders correctly 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               We believe in the power of prayer.

--- a/test/containers/Family/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Family/__snapshots__/index.spec.tsx.snap
@@ -28,7 +28,7 @@ exports[`Family > renders correctly without images 1`] = `
         </h3>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               <i>

--- a/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
+++ b/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
@@ -73,7 +73,7 @@ exports[`NewsContent > renders the news page 1`] = `
         </button>
         <button
           class="deleteNewsButton"
-          style="background-color: red; color: white;"
+          sx="[object Object]"
         >
           Delete
         </button>

--- a/test/containers/Youth/__snapshots__/YouthContent.spec.tsx.snap
+++ b/test/containers/Youth/__snapshots__/YouthContent.spec.tsx.snap
@@ -28,7 +28,7 @@ exports[`YouthContent > renders the youth page 1`] = `
         </h3>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               <i>
@@ -43,7 +43,7 @@ exports[`YouthContent > renders the youth page 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               <i>

--- a/test/containers/Youth/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Youth/__snapshots__/index.spec.tsx.snap
@@ -28,7 +28,7 @@ exports[`Youth > renders correctly without images 1`] = `
         </h3>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               <i>
@@ -43,7 +43,7 @@ exports[`Youth > renders correctly without images 1`] = `
         </p>
         <p>
           <span
-            style="color: rgb(0, 51, 102);"
+            class="brand-emphasis"
           >
             <strong>
               <i>

--- a/test/e2e/mobile-header.spec.ts
+++ b/test/e2e/mobile-header.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+
+// Regression guard for CollegeLutheran#711 (dark-mode header on phones):
+// the theme selector must stay visible alongside the hamburger and must NOT
+// overlap the subtitle text. Mobile-only; needs the dark-mode feature served
+// (run against a local dev/preview via BASE_URL until it ships to production).
+test.use({ ignoreHTTPSErrors: true });
+
+test.describe('mobile dark-mode header (#711)', () => {
+  test('hamburger + theme selector show and the selector does not overlap the subtitle', async ({ page }) => {
+    test.skip(test.info().project.name !== 'mobile', 'phone-layout test (mobile project only)');
+    await page.goto('/');
+    await page.evaluate(() => localStorage.setItem('clc-theme-preference', 'dark'));
+    await page.reload();
+
+    const hamburger = page.locator('#mobilemenutoggle');
+    const selector = page.locator('.theme-mode-selector');
+    const subtitle = page.locator('.subTitle');
+
+    await expect(hamburger).toBeVisible();
+    await expect(selector).toBeVisible();
+
+    const sel = await selector.boundingBox();
+    const sub = await subtitle.boundingBox();
+    expect(sel, 'theme selector should render').not.toBeNull();
+    expect(sub, 'subtitle should render').not.toBeNull();
+
+    const overlaps = sel!.x < sub!.x + sub!.width
+      && sel!.x + sel!.width > sub!.x
+      && sel!.y < sub!.y + sub!.height
+      && sel!.y + sel!.height > sub!.y;
+    expect(overlaps, 'theme selector must not overlap the subtitle text').toBe(false);
+  });
+
+  test('subtitle stays inside the header (no overflow) on a narrow 320px phone', async ({ page }) => {
+    test.skip(test.info().project.name !== 'mobile', 'phone-layout test (mobile project only)');
+    await page.setViewportSize({ width: 320, height: 740 });
+    await page.goto('/');
+    await page.evaluate(() => localStorage.setItem('clc-theme-preference', 'dark'));
+    await page.reload();
+
+    const header = await page.locator('.home-header').boundingBox();
+    const subtitle = await page.locator('.subTitle').boundingBox();
+    expect(header, 'header should render').not.toBeNull();
+    expect(subtitle, 'subtitle should render').not.toBeNull();
+
+    expect(
+      subtitle!.y + subtitle!.height,
+      'subtitle must not spill below the header',
+    ).toBeLessThanOrEqual(header!.y + header!.height + 1);
+  });
+});


### PR DESCRIPTION
## Summary
Dark mode for the College Lutheran site. First task of the Codex/GPT-5.5 frontend-agent eval (web-jam-tools#105).

- **[Codex/GPT-5.5]** Add light/dark/system theming via a new MUI `ThemeProvider` — `system` default, `prefers-color-scheme` sync, `localStorage` persistence; derives a navy+gold dark palette from the existing CLC brand colors and bridges legacy SCSS through CSS custom properties.
- **[Codex/GPT-5.5]** Add a segmented light/system/dark selector in the header.
- **[Codex/GPT-5.5]** Dark-mode footer fix: white backing behind the ELCA logo so it stays visible.
- **[Opus]** Fix mobile header regressions: restore the hamburger (was hidden behind the selector), stop the selector overlapping the subtitle, and grow the header so content never overflows at narrow widths (320–414px).
- **[Opus]** Add a Playwright mobile regression test guarding both no-overlap (393px) and no-overflow (320px).

Closes #711

## How to test locally
Run the gate plus the new e2e (e2e needs the app served, since dark mode isn't on prod yet):

`npm test` · `npm run typecheck` · `BASE_URL=https://localhost:7777 npx playwright test mobile-header --project=mobile`

Expect all green; toggle light/dark/system and confirm persistence + no white flashes.

## Test evidence
test:lint (stylelint + eslint) clean
test:unit — 51 files | 153 tests passed
typecheck — tsc --noEmit clean
build — vite built ok
e2e — 2 passed (no-overlap @393px, no-overflow @320px)
Visually verified at 320 / 360 / 390 / 414px in dark mode.

🤖 Work by Codex CLI — GPT-5.5 + Opus 4.8