### PR TITLE
AGENTS.md: branch & memory hygiene — never push to merged branches; lessons ship inside the PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,20 @@ than adding a UI library — e.g. a loading spinner is `<CircularProgress />` fr
 - e2e tests (`npm run test:e2e`, Playwright) need a browser install and a running
   app; you don't need to run them — unit tests + lint are the gate.
 
+## Branch & memory hygiene
+
+- One branch per task: never create or push any branch other than the one
+  created for the current task.
+- Once your PR is merged or closed, its branch is DEAD — never commit to it or
+  push it again. Follow-up work (including afterthoughts like docs or lessons
+  learned) starts on a NEW branch off the latest `dev`, with its own PR.
+- Save lessons BEFORE the merge, not after: anything you learned during the task
+  worth keeping (build quirks, selector gotchas, testing patterns — e.g. the
+  output of a `/learn`-style memory pass) gets committed to this file's Memory
+  section on the SAME task branch while the PR is still open, so it ships inside
+  the PR. A post-merge push to the old branch strands the lesson and forces
+  manual cleanup.
+
 ## Memory
 - **News Flow:** Creating "News" is handled via the `ChangeNewsPage` component in `src/containers/AdminDashboard/AdminDashboardContent.tsx`. Updating and Deleting news happens through `src/containers/News/EditNewsDialog.tsx`.
 - **Async Testing:** When components have `await` calls that disable buttons (like during API calls), tests using `@testing-library/react` need to mock functions to return Promises (`vi.fn(() => Promise.resolve())`) and interactions should be wrapped in `await act(async () => { ... })` to properly flush React state.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.28",
+  "version": "2.1.29",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {


### PR DESCRIPTION
## Summary
Adds a 'Branch & memory hygiene' section to AGENTS.md so agy/Flash stops pushing to merged branches: one branch per task; a merged/closed PR's branch is dead (follow-ups start fresh off dev); lessons learned ship inside the open PR, never as a post-merge push. Same rule landing in JaMmusic (#1178) and AppersonAuto. Docs-only; version 2.1.29.

Closes #768

## How to test locally
Docs-only (AGENTS.md + version bump) — no runtime surface. Review the rendered section; confirm no src/test changes: git diff dev --stat

## Test evidence
git diff dev --stat: AGENTS.md +15 lines, package.json version 2.1.28→2.1.29 only. No code touched, so lint/unit gates unaffected.

🤖 Work by Claude Code — Fable 5