### PR TITLE
Add axe (vitest-axe) accessibility tests

### DIFF
--- a/__mocks__/@mui/material.tsx
+++ b/__mocks__/@mui/material.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function TextField(props: any) {
-  const { children } = props;
-  return <input {...props}>{children}</input>;
+  // The real MUI TextField renders its `label` prop as an accessible <label>;
+  // surface it as aria-label here so runtime a11y (axe) checks stay honest.
+  const { children, label, ...rest } = props;
+  return <input aria-label={label} {...rest}>{children}</input>;
 }
 
 export function Checkbox(props: any) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.28",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.1.28",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -52,6 +52,7 @@
         "@testing-library/react": "^16.3.2",
         "@vitest/coverage-v8": "^4.1.7",
         "@vitest/eslint-plugin": "^1.6.16",
+        "axe-core": "^4.12.1",
         "eslint": "^10.4.0",
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-json": "^4.0.1",
@@ -68,7 +69,8 @@
         "stylelint-config-standard": "^40.0.0",
         "stylelint-scss": "^7.0.0",
         "typescript-eslint": "^8.59.1",
-        "vitest": "^4.1.7"
+        "vitest": "^4.1.7",
+        "vitest-axe": "^0.1.0"
       },
       "engines": {
         "node": "24.18.0"
@@ -3696,6 +3698,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -3995,8 +4010,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -6177,6 +6191,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -9094,6 +9115,24 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
       }
     },
     "node_modules/vscode-json-languageservice": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.1.29",
+  "version": "2.2.0",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {
@@ -89,6 +89,7 @@
     "@testing-library/react": "^16.3.2",
     "@vitest/coverage-v8": "^4.1.7",
     "@vitest/eslint-plugin": "^1.6.16",
+    "axe-core": "^4.12.1",
     "eslint": "^10.4.0",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-json": "^4.0.1",
@@ -105,6 +106,7 @@
     "stylelint-config-standard": "^40.0.0",
     "stylelint-scss": "^7.0.0",
     "typescript-eslint": "^8.59.1",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.7",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/src/App/AppTemplate/DrawerContainer.tsx
+++ b/src/App/AppTemplate/DrawerContainer.tsx
@@ -11,8 +11,12 @@ export function DrawerContainer(props:IdrawerContainerProps) {
     className, handleClose, handleKeyPress,
   } = props;
   const theme = useTheme();
+  // Click-to-close catch-all around the drawer. It must NOT be a focusable
+  // button: the nav links inside are the interactive elements (each closes the
+  // menu itself), and a role="button" wrapper with focusable children violates
+  // axe's nested-interactive rule (CollegeLutheran#773).
   return (
-    <div tabIndex={0} role="button" id="sidebar" onClick={handleClose} onKeyPress={handleKeyPress} className={className}>
+    <div role="presentation" id="sidebar" onClick={handleClose} onKeyPress={handleKeyPress} className={className}>
       <div className="drawer" style={{ backgroundColor: theme.palette.background.paper, zIndex: -1, position: 'relative' }}>
         <div className="navImage">
           <img

--- a/src/containers/Family/FamilyContent.tsx
+++ b/src/containers/Family/FamilyContent.tsx
@@ -6,7 +6,7 @@ import PicSlider from '../../components/PicSlider';
 import ELCALogo from '../../components/elcaLogo';
 
 // eslint-disable-next-line max-len
-const additionalContent = '<hr><h5>Resources for Families</h5><p><strong><em>Roots and Wings</em></strong>, a monthly publication of the Virginia Synod that provides suggestions of daily family time activities:<a target="_blank" href="https://www.vasynod.org/ministries/roots-and-wings/">https://www.vasynod.org/ministries/roots-and-wings/</a></p><p><strong>Ideas to bring worship to the home:</strong>&nbsp;<a target="_blank" href="https://www.vasynod.org/wp-content/uploads/2012/11/Worship-in-the-Home.pdf">https://www.vasynod.org/wp-content/uploads/2012/11/Worship-in-the-Home.pdf</a></p>';
+const additionalContent = '<hr><h3 style="font-size:16pt;font-weight:bold">Resources for Families</h3><p><strong><em>Roots and Wings</em></strong>, a monthly publication of the Virginia Synod that provides suggestions of daily family time activities:<a target="_blank" href="https://www.vasynod.org/ministries/roots-and-wings/">https://www.vasynod.org/ministries/roots-and-wings/</a></p><p><strong>Ideas to bring worship to the home:</strong>&nbsp;<a target="_blank" href="https://www.vasynod.org/wp-content/uploads/2012/11/Worship-in-the-Home.pdf">https://www.vasynod.org/wp-content/uploads/2012/11/Worship-in-the-Home.pdf</a></p>';
 const FamilySection = () => (
   <section style={{ textAlign: 'left' }}>
     <p>

--- a/src/containers/Homepage/About.tsx
+++ b/src/containers/Homepage/About.tsx
@@ -81,7 +81,9 @@ export const About = ({
               The church is situated on College Avenue, within easy walking distance of Roanoke College.
               College Lutheran Church is part of the Evangelical Lutheran Church in America (ELCA).
             </p>
-            <h5 style={{ fontWeight: 'bold', marginTop: '35px' }}>{parser(homePage && homePage.title ? homePage.title : '')}</h5>
+            {homePage?.title ? (
+              <h3 style={{ fontWeight: 'bold', marginTop: '35px', fontSize: '16pt' }}>{parser(homePage.title)}</h3>
+            ) : null}
             <section style={{ marginTop: '20px', textAlign: 'left', marginBottom: '35px' }}>
               {parser(homePage && homePage.comments ? homePage.comments : '')}
             </section>

--- a/src/containers/LiveStream/index.tsx
+++ b/src/containers/LiveStream/index.tsx
@@ -42,7 +42,7 @@ export const LiveStream = ({ width }: LiveStreamProps) => {
   };
   return (
     <div style={{ margin: 'auto', width: '100%', textAlign: 'center' }}>
-      {width > 600 ? <h5 style={{ marginTop: '0.5rem' }}>Welcome to Our Livestream Page</h5> : null}
+      {width > 600 ? <h3 style={{ marginTop: '0.5rem', fontSize: '16pt', fontWeight: 'bold' }}>Welcome to Our Livestream Page</h3> : null}
       <p>
         The video below is embedded from YouTube, however if it does not play properly,
         please click one of the following links to view the live church service.

--- a/src/containers/Youth/YouthContent.tsx
+++ b/src/containers/Youth/YouthContent.tsx
@@ -61,7 +61,9 @@ export const YouthContent = (
           </p>
           <FaithWithoutWorks />
           <hr />
-          <h5 style={{ fontWeight: 'bold', marginTop: '35px' }}>{parser(youthPage && youthPage.title ? youthPage.title : '')}</h5>
+          {youthPage?.title ? (
+            <h3 style={{ fontWeight: 'bold', marginTop: '35px', fontSize: '16pt' }}>{parser(youthPage.title)}</h3>
+          ) : null}
           <section style={{ marginTop: '20px', textAlign: 'left', marginBottom: '35px' }}>
             {parser(youthPage && youthPage.comments ? youthPage.comments : '')}
           </section>

--- a/test/App/a11y.spec.tsx
+++ b/test/App/a11y.spec.tsx
@@ -1,0 +1,92 @@
+/**
+ * Runtime accessibility checks (CollegeLutheran#773).
+ *
+ * Renders the app's main routes through the real AppTemplate + theme provider
+ * and asserts zero axe-core violations in BOTH theme modes (dark mode applies
+ * via document.documentElement.dataset.themeMode — see src/App/theme.tsx).
+ *
+ * Limitation: jsdom performs no layout and `css: false` keeps stylesheets out
+ * of the test DOM, so axe's color-contrast rule cannot run meaningfully here
+ * (vitest-axe disables it by default in jsdom). These tests cover the
+ * structural/ARIA rules; contrast stays a manual/e2e concern.
+ */
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { GoogleOAuthProvider } from '@react-oauth/google';
+import { act, render } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { App } from 'src/App';
+import store from 'src/redux/store';
+import { CollegeLutheranThemeProvider, ResolvedThemeMode } from 'src/App/theme';
+
+const mainRoutes = [
+  '/',
+  '/music',
+  '/belief',
+  '/family',
+  '/giving',
+  '/staff',
+  '/youth',
+  '/news',
+  '/calendar',
+  '/livestream',
+];
+
+function installMatchMedia() {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
+async function renderRoute(route: string, mode: ResolvedThemeMode) {
+  localStorage.setItem('clc-theme-preference', mode);
+  const view = render(
+    <GoogleOAuthProvider clientId="test-client-id">
+      <Provider store={store.store}>
+        <CollegeLutheranThemeProvider>
+          <MemoryRouter initialEntries={[route]}>
+            <App />
+          </MemoryRouter>
+        </CollegeLutheranThemeProvider>
+      </Provider>
+    </GoogleOAuthProvider>,
+  );
+  // Flush the data-fetching effects (stubbed fetch) so state settles inside act.
+  await act(async () => { await Promise.resolve(); });
+  expect(document.documentElement.dataset.themeMode).toBe(mode);
+  return view;
+}
+
+describe('axe accessibility (runtime)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    installMatchMedia();
+    // Pages fetch backend content on mount; keep the suite offline and let the
+    // components take their error/empty-content paths.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({}),
+    }) as unknown as typeof fetch;
+  });
+
+  (['light', 'dark'] as ResolvedThemeMode[]).forEach((mode) => {
+    describe(`${mode} mode`, () => {
+      mainRoutes.forEach((route) => {
+        it(`has no axe violations on ${route}`, async () => {
+          const { container } = await renderRoute(route, mode);
+          // jsdom cannot post messages into embedded iframes (Calendar,
+          // LiveStream, Giving embeds), so keep axe out of frame contents.
+          const results = await axe(container, { iframes: false });
+          expect(results).toHaveNoViolations();
+        });
+      });
+    });
+  });
+});

--- a/test/containers/AdminDashboard/AdminDashboardContent.spec.tsx
+++ b/test/containers/AdminDashboard/AdminDashboardContent.spec.tsx
@@ -36,13 +36,13 @@ describe('AdminDashboard Content', () => {
   });
   it('handles setTitle for ChangeNewsPage', () => {
     const { container } = render(<ChangeNewsPage />);
-    const title = container.querySelector('input[label="Title"]') as HTMLInputElement | null;
+    const title = container.querySelector('input[aria-label="Title"]') as HTMLInputElement | null;
     expect(title).not.toBeNull();
     fireEvent.change(title!, { target: { value: 'somethin' } });
   });
   it('handles setUrl for ChangeNewsPage', () => {
     const { container } = render(<ChangeNewsPage />);
-    const url = container.querySelector('input[label="Url"]') as HTMLInputElement | null;
+    const url = container.querySelector('input[aria-label="Url"]') as HTMLInputElement | null;
     expect(url).not.toBeNull();
     fireEvent.change(url!, { target: { value: 'anythin' } });
   });

--- a/test/containers/AdminDashboard/EditPic/EditPicDialog.spec.tsx
+++ b/test/containers/AdminDashboard/EditPic/EditPicDialog.spec.tsx
@@ -16,8 +16,8 @@ describe('EditPicDialog', () => {
     const setEditPic = vi.fn();
     const props = { onClose: vi.fn(), editPic: defaultPic, setEditPic };
     const { container } = render(<EditPicDialog {...props} />);
-    const url = container.querySelector('input[label="* URL"]') as HTMLInputElement | null;
-    const title = container.querySelector('input[label="* Title"]') as HTMLInputElement | null;
+    const url = container.querySelector('input[aria-label="* URL"]') as HTMLInputElement | null;
+    const title = container.querySelector('input[aria-label="* Title"]') as HTMLInputElement | null;
     expect(url).not.toBeNull();
     expect(title).not.toBeNull();
     fireEvent.change(url!, { target: { value: 'url' } });

--- a/test/containers/AdminDashboard/EditPic/__snapshots__/EditPicDialog.spec.tsx.snap
+++ b/test/containers/AdminDashboard/EditPic/__snapshots__/EditPicDialog.spec.tsx.snap
@@ -12,13 +12,13 @@ exports[`EditPicDialog > renders EditPicDialog 1`] = `
       sx="[object Object]"
     >
       <input
-        label="* URL"
+        aria-label="* URL"
         sx="[object Object]"
         type="text"
         value=""
       />
       <input
-        label="* Title"
+        aria-label="* Title"
         sx="[object Object]"
         type="text"
         value=""

--- a/test/containers/AdminDashboard/EditPic/__snapshots__/EditPicTable.spec.tsx.snap
+++ b/test/containers/AdminDashboard/EditPic/__snapshots__/EditPicTable.spec.tsx.snap
@@ -560,13 +560,13 @@ exports[`EditPicTable > renders EditPicTable 1`] = `
         sx="[object Object]"
       >
         <input
-          label="* URL"
+          aria-label="* URL"
           sx="[object Object]"
           type="text"
           value=""
         />
         <input
-          label="* Title"
+          aria-label="* Title"
           sx="[object Object]"
           type="text"
           value=""

--- a/test/containers/AdminDashboard/__snapshots__/CreatePicDialog.spec.tsx.snap
+++ b/test/containers/AdminDashboard/__snapshots__/CreatePicDialog.spec.tsx.snap
@@ -18,15 +18,15 @@ exports[`CreatePicDialog > renders CreatePicDialog 1`] = `
         Enter all *required fields to create a new picture.
       </div>
       <input
+        aria-label="* Url"
         id="url-textfield"
-        label="* Url"
         sx="[object Object]"
         type="text"
         value=""
       />
       <input
+        aria-label="* Title"
         id="title-textfield"
-        label="* Title"
         sx="[object Object]"
         type="text"
         value=""

--- a/test/containers/AdminDashboard/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/AdminDashboard/__snapshots__/index.spec.tsx.snap
@@ -56,12 +56,12 @@ exports[`Dashboard Container > renders AdminDashboard 1`] = `
       </h5>
       <div>
         <input
-          label="Title"
+          aria-label="Title"
           sx="[object Object]"
           value=""
         />
         <input
-          label="Url"
+          aria-label="Url"
           value=""
         />
         <div

--- a/test/containers/Family/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Family/__snapshots__/index.spec.tsx.snap
@@ -65,9 +65,11 @@ exports[`Family > renders correctly without images 1`] = `
         >
            
           <hr />
-          <h5>
+          <h3
+            style="font-size: 16pt; font-weight: bold;"
+          >
             Resources for Families
-          </h5>
+          </h3>
           <p>
             <strong>
               <em>

--- a/test/containers/Homepage/__snapshots__/About.spec.tsx.snap
+++ b/test/containers/Homepage/__snapshots__/About.spec.tsx.snap
@@ -21,9 +21,6 @@ exports[`About > renders the about page 1`] = `
           >
             College Lutheran Church is located in Southwest Virginia in the beautiful city of Salem, right next to Roanoke, VA. The church is situated on College Avenue, within easy walking distance of Roanoke College. College Lutheran Church is part of the Evangelical Lutheran Church in America (ELCA).
           </p>
-          <h5
-            style="font-weight: bold; margin-top: 35px;"
-          />
           <section
             style="margin-top: 20px; text-align: left; margin-bottom: 35px;"
           />

--- a/test/containers/News/EditNewsDialog.spec.tsx
+++ b/test/containers/News/EditNewsDialog.spec.tsx
@@ -29,8 +29,8 @@ describe('EditNewsDialog', () => {
       editNewsState: { editNews: defaultNews, setEditNews },
     };
     const { container } = render(<EditNewsContent {...props} />);
-    const urlInput = container.querySelector('input[label="* URL"]') as HTMLInputElement | null;
-    const titleInput = container.querySelector('input[label="* Title"]') as HTMLInputElement | null;
+    const urlInput = container.querySelector('input[aria-label="* URL"]') as HTMLInputElement | null;
+    const titleInput = container.querySelector('input[aria-label="* Title"]') as HTMLInputElement | null;
     expect(urlInput).not.toBeNull();
     expect(titleInput).not.toBeNull();
     fireEvent.change(urlInput!, { target: { value: 'url' } });

--- a/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
+++ b/test/containers/News/__snapshots__/NewsContent.spec.tsx.snap
@@ -43,15 +43,15 @@ exports[`NewsContent > renders the news page 1`] = `
         sx="[object Object]"
       >
         <input
+          aria-label="* URL"
           class="url"
-          label="* URL"
           sx="[object Object]"
           type="text"
           value=""
         />
         <input
+          aria-label="* Title"
           class="title"
-          label="* Title"
           sx="[object Object]"
           type="text"
           value=""

--- a/test/containers/Youth/__snapshots__/YouthContent.spec.tsx.snap
+++ b/test/containers/Youth/__snapshots__/YouthContent.spec.tsx.snap
@@ -60,9 +60,6 @@ exports[`YouthContent > renders the youth page 1`] = `
           We invite you to come be part of our active, growing youth ministry program at any or all of our upcoming events.
         </p>
         <hr />
-        <h5
-          style="font-weight: bold; margin-top: 35px;"
-        />
         <section
           style="margin-top: 20px; text-align: left; margin-bottom: 35px;"
         />

--- a/test/containers/Youth/__snapshots__/index.spec.tsx.snap
+++ b/test/containers/Youth/__snapshots__/index.spec.tsx.snap
@@ -60,9 +60,6 @@ exports[`Youth > renders correctly without images 1`] = `
           We invite you to come be part of our active, growing youth ministry program at any or all of our upcoming events.
         </p>
         <hr />
-        <h5
-          style="font-weight: bold; margin-top: 35px;"
-        />
         <section
           style="margin-top: 20px; text-align: left; margin-bottom: 35px;"
         />

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,7 +1,13 @@
 import { config } from 'dotenv';
-import { vi } from 'vitest';
+import { expect, vi } from 'vitest';
+import * as axeMatchers from 'vitest-axe/matchers';
+
+expect.extend(axeMatchers);
 
 config();
+
+// Vite's `define` block is empty in test mode, so stub the build-time version global.
+(globalThis as Record<string, unknown>).__APP_VERSION__ = 'test';
 
 vi.mock('@mui/material');
 vi.mock('@tinymce/tinymce-react');

--- a/types/vitest-globals/index.d.ts
+++ b/types/vitest-globals/index.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vitest/globals" />
+
+import 'vitest';
+
+declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  interface Assertion<T = any> {
+    toHaveNoViolations(): T;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `vitest-axe` + `axe-core` as devDependencies and wire the matcher into `test/vitest.setup.ts` (bump to 2.2.0)
- New `test/App/a11y.spec.tsx`: renders the app through the real providers (GoogleOAuth, redux store, theme provider, MemoryRouter) at each of the 10 main routes (`/`, `/music`, `/belief`, `/family`, `/giving`, `/staff`, `/youth`, `/news`, `/calendar`, `/livestream`) and asserts zero axe violations in BOTH theme modes — dark mode applied for real via `document.documentElement.dataset.themeMode` (asserted per test); 20 tests total, running inside the normal `npm test`
- **Real violations axe found, fixed here:**
  - `nested-interactive` (every route): the drawer's click-to-close wrapper (`#sidebar`) was `role="button"` + `tabIndex=0` with focusable nav links inside; now `role="presentation"` — the links themselves already close the menu
  - `empty-heading` + `heading-order` (`/`, `/youth`): CMS page title rendered an empty `<h5>` when content is absent and skipped h2→h5; now a conditional `<h3>` kept at the previous 16pt size
  - `heading-order` (`/family`, `/livestream`): `<h5>` → `<h3>` with 16pt preserved
  - `label` (`/news` admin inputs): mock artifact — the MUI TextField mock dropped the `label` prop; it now surfaces it as `aria-label` (the real MUI TextField renders a proper label), test selectors/snapshots updated
- **Limitation (per issue):** jsdom performs no layout and vitest runs with `css: false`, so axe's color-contrast rule cannot run meaningfully (vitest-axe disables it in jsdom); these tests cover the structural/ARIA rules and axe runs with `iframes: false` because jsdom can't message the embedded Calendar/LiveStream/Giving frames. Contrast remains a manual/e2e concern.

Closes #773

## How to test locally
Run the full repo gate (lint + typecheck + unit incl. the 20 new a11y tests):
```sh
npm test
```
Expect: stylelint + eslint clean, tsc clean, 52 test files / 172 tests passing.

Exercise the a11y suite and coverage directly:
```sh
npx vitest run test/App/a11y.spec.tsx --coverage.enabled=false
npx vitest run --coverage
```
Expect: 20/20 a11y tests green; coverage ≥ gate (stmts 90.15%, branch 83.04%, funcs 87.07%, lines 91.64%).

Verify the visible fixes in the app:
```sh
npm run dev
```
Open http://localhost:7777 — page-title headings on Home/Youth/Family/Livestream look unchanged (same 16pt bold) but are now `h3`; Home/Youth show no stray empty heading gap when CMS content is missing; the mobile drawer still closes when you click/tap anywhere in it or on a nav link.

## Test evidence
```
> collegelutheran@2.2.0 test
> npm run test:lint && npm run typecheck && npm run test:unit

> collegelutheran@2.2.0 test:lint
> npm run test:stylelint && eslint .

> collegelutheran@2.2.0 test:stylelint
> stylelint "src/styles/**/*.scss"

> collegelutheran@2.2.0 typecheck
> tsc --noEmit

> collegelutheran@2.2.0 test:unit
> vitest run

 RUN  v4.1.9 /home/joshua/WebJamApps/CollegeLutheran

 Test Files  52 passed (52)
      Tests  172 passed (172)
   Duration  10.38s
```
Coverage run (`npx vitest run --coverage`):
```
All files          |   90.15 |    83.04 |   87.07 |   91.64 |
```
Warnings observed (pre-existing, not from this PR): repeated jsdom "Not implemented: HTMLCanvasElement's getContext()" noise during unit tests. 9 snapshots were updated via `npm run test:unit-u` (heading + aria-label changes), then the full `npm test` re-run green.

🤖 Work by Claude Code — Sonnet 5