### PR TITLE
docs(agents): Fix agy attribution example in AGENTS.md PR-body conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,4 +60,4 @@ than adding a UI library — e.g. a loading spinner is `<CircularProgress />` fr
 - **Summary**: markdown bullet points, one change per bullet — never a run-on paragraph.
 - **Test evidence**: paste the REAL runner output verbatim (the lines showing pass/fail and test counts), inside a ``` fence — never a description like "all tests passed". If the output has scrolled out of view, re-run the test command and paste what it prints.
 - **Test plan**: exact commands and manual steps that exercise the change (start command, route/page, what to click, expected visible result) — a green test suite alone is not a plan.
-- **Attribution**: `--author` names the model actually doing the work. Antigravity/agy sessions are ALWAYS `Antigravity — Gemini 3.5 Flash (Medium)` or `(High)` — never write any other Gemini model name (models misremember their own identity; use this exact string).
+- **Attribution**: `--author` names the model actually doing the work. Antigravity/agy sessions are ALWAYS `agy — Gemini 3.5 Flash (Medium)` or `(High)` — never write any other Gemini model name (models misremember their own identity; use this exact string).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {


### PR DESCRIPTION
## Summary
- Fix agy attribution example in AGENTS.md PR-body conventions: `Antigravity — <model>` → `agy — <model>`, matching the footer web-jam-tools' create-draft-pr.sh actually composes via FORCED_PR_AUTHOR (wjt#162 close-out)

## How to test locally
\`\`\`sh
grep 'agy — Gemini 3.5 Flash' AGENTS.md
npm test
\`\`\`

Expected: AGENTS.md line shows \`agy — Gemini 3.5 Flash (Medium)\` or \`(High)\` in attribution example; all lint/test suites pass.

## Test evidence
```
\`\`\`sh
npm test
\`\`\`

Output:
- Test Files  52 passed (52)
- Tests  172 passed (172)
```

🤖 Work by Claude Code — Haiku 4.5