### PR TITLE
website caches old broken version of website

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "collegelutheran",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "collegelutheran",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collegelutheran",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "collegelutheran.org",
   "main": "dist/index.html",
   "repository": {

--- a/server.mjs
+++ b/server.mjs
@@ -15,9 +15,23 @@ app.use((_req, res, next) => {
   next();
 });
 
-app.use(express.static(path.normalize(path.join(__dirname, 'dist'))));
+const distDir = path.normalize(path.join(__dirname, 'dist'));
+
+app.use('/assets', express.static(path.join(distDir, 'assets'), {
+  setHeaders: (res) => {
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+  },
+}));
+
+app.use(express.static(distDir, {
+  setHeaders: (res, filePath) => {
+    res.setHeader('Cache-Control', filePath.endsWith('.html') ? 'no-store' : 'no-cache');
+  },
+}));
+
 app.get('/*path', (_request, response) => {
-  response.sendFile(path.normalize(path.join(__dirname, 'dist/index.html')));
+  response.setHeader('Cache-Control', 'no-store');
+  response.sendFile(path.join(distDir, 'index.html'));
 });
 
 const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -3,7 +3,12 @@ import {
 } from 'vitest';
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import app from '../server.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe('server.mjs', () => {
   let server: Server;
@@ -31,5 +36,24 @@ describe('server.mjs', () => {
   it('sets the COOP header on the root path as well', async () => {
     const res = await fetch(`${baseUrl}/`);
     expect(res.headers.get('cross-origin-opener-policy')).toBe('same-origin-allow-popups');
+  });
+
+  it('sets Cache-Control: no-store on the root path', async () => {
+    const res = await fetch(`${baseUrl}/`);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('sets Cache-Control: no-store on an arbitrary SPA route', async () => {
+    const res = await fetch(`${baseUrl}/any-path`);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('sets Cache-Control: public, max-age=31536000, immutable on a hashed asset file', async () => {
+    const assetsDir = path.join(__dirname, '..', 'dist', 'assets');
+    const [assetFile] = readdirSync(assetsDir);
+    const res = await fetch(`${baseUrl}/assets/${assetFile}`);
+    const cacheControl = res.headers.get('cache-control');
+    expect(cacheControl).toContain('max-age=31536000');
+    expect(cacheControl).toContain('immutable');
   });
 });


### PR DESCRIPTION
## Summary
- Diagnosis: `server.mjs` served everything through bare `express.static` + `res.sendFile`, which ships serve-static's default `public, max-age=0`. That is weak enough that some browsers (notably Chrome/Android) reuse a stored `index.html` across back/forward nav and tab restore.
- That stale HTML references content-hashed asset filenames from a prior Vite build, which no longer exist after a deploy — so the site comes up broken until the user manually clears their cache.
- Fix: explicit `Cache-Control` per path in `server.mjs`:

| Path | Cache-Control | Rationale |
|---|---|---|
| `/assets/*` (Vite content-hashed) | `public, max-age=31536000, immutable` | filename changes every build, can never go stale |
| `index.html` + SPA fallback route | `no-store` | must always be fetched fresh — this is the actual bug fix |
| everything else in `dist/` | `no-cache` | forces revalidation, cheap 304s |

- Extended `test/server.spec.ts` (same real `app.listen(0)` + global `fetch` pattern already in the file, no supertest added) with 3 new assertions covering the table above; the asset filename is discovered at test time from `dist/assets/`, never hardcoded.

Closes #783

## How to test locally
Run the full gate:
```sh
npm test
```
Expect: lint + typecheck + all vitest files green.

Exercise the actual fix — start the server and hit each path class:
```sh
node -e "
import('./server.mjs').then(({ default: app }) => {
  const server = app.listen(0, async () => {
    const port = server.address().port;
    const base = \`http://127.0.0.1:\${port}\`;
    const fs = await import('node:fs');
    const assetFile = fs.readdirSync('dist/assets')[0];
    console.log('root:', (await fetch(base + '/')).headers.get('cache-control'));
    console.log('spa route:', (await fetch(base + '/any-path')).headers.get('cache-control'));
    console.log('asset:', (await fetch(base + '/assets/' + assetFile)).headers.get('cache-control'));
    server.close();
  });
});
"
```
Expect: `root: no-store`, `spa route: no-store`, `asset: public, max-age=31536000, immutable`.

## Test evidence
Real request against the running server (verifying the exact header values before writing the automated tests):
```
root: no-store
spa route: no-store
asset (ajax-loader-BcnMEykj.gif): public, max-age=31536000, immutable
```

Full `npm test` output:
```
> collegelutheran@2.2.3 test
> npm run test:lint && npm run typecheck && npm run test:unit

> collegelutheran@2.2.3 test:lint
> npm run test:stylelint && eslint .

> collegelutheran@2.2.3 test:stylelint
> stylelint "src/styles/**/*.scss"

> collegelutheran@2.2.3 typecheck
> tsc --noEmit

> collegelutheran@2.2.3 test:unit
> vitest run

 RUN  v4.1.9 /home/joshua/WebJamApps/CollegeLutheran

 Test Files  52 passed (52)
      Tests  175 passed (175)
   Start at  02:11:15
   Duration  10.88s (transform 2.25s, setup 2.36s, import 27.89s, tests 11.84s, environment 53.56s)
```

🤖 Work by Claude Code — Sonnet 5